### PR TITLE
HTTP/2 and HTTP/3 support

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(cpr PRIVATE
     cpr/verbose.h
     cpr/interface.h
     cpr/redirect.h
+    cpr/http_version.h
 )
 
 install(DIRECTORY cpr DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/include/cpr/cpr.h
+++ b/include/cpr/cpr.h
@@ -4,6 +4,7 @@
 #include "cpr/api.h"
 #include "cpr/auth.h"
 #include "cpr/cprtypes.h"
+#include "cpr/http_version.h"
 #include "cpr/interface.h"
 #include "cpr/redirect.h"
 #include "cpr/response.h"

--- a/include/cpr/http_version.h
+++ b/include/cpr/http_version.h
@@ -1,0 +1,67 @@
+#ifndef CPR_HTTP_VERSION_H
+#define CPR_HTTP_VERSION_H
+
+#include <curl/curlver.h>
+
+namespace cpr {
+enum class HttpVersionCode {
+    /**
+     * Let libcurl decide which version is the best.
+     **/
+    VERSION_NONE,
+    /**
+     * Enforce HTTP 1.0 requests.
+     **/
+    VERSION_1_0,
+    /**
+     * Enforce HTTP 1.1 requests.
+     **/
+    VERSION_1_1,
+#if LIBCURL_VERSION_NUM >= 0x072100 // 7.33.0
+    /**
+     * Attempt HTTP 2.0 requests.
+     * Fallback to HTTP 1.1 if negotiation fails.
+     **/
+    VERSION_2_0,
+#endif
+#if LIBCURL_VERSION_NUM >= 0x072F00 // 7.47.0
+    /**
+     * Attempt HTTP 2.0 for HTTPS requests only.
+     * Fallback to HTTP 1.1 if negotiation fails.
+     * HTTP 1.1 will be used for HTTP connections.
+     **/
+    VERSION_2_0_TLS,
+#endif
+#if LIBCURL_VERSION_NUM >= 0x073100 // 7.49.0
+    /**
+     * Start HTTP 2.0 for HTTP requests.
+     * Requires prior knowledge that the server supports HTTP 2.0.
+     * For HTTPS requests we will negotiate the protocol version in the TLS handshake.
+     **/
+    VERSION_2_0_PRIOR_KNOWLEDGE,
+#endif
+#if LIBCURL_VERSION_NUM >= 0x074200 // 7.66.0
+    /**
+     * Attempt HTTP 3.0 requests.
+     * Requires prior knowledge that the server supports HTTP 3.0 since there is no gracefully downgrade.
+     * Fallback to HTTP 1.1 if negotiation fails.
+     **/
+    VERSION_3_0
+#endif
+};
+
+class HttpVersion {
+  public:
+    /**
+     * The HTTP version that should be used by libcurl when initiating a HTTP(S) connection.
+     * Default: HttpVersionCode::VERSION_NONE
+     **/
+    HttpVersionCode code = HttpVersionCode::VERSION_NONE;
+
+    HttpVersion() = default;
+    explicit HttpVersion(HttpVersionCode code) : code(code) {}
+};
+
+} // namespace cpr
+
+#endif

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -14,6 +14,7 @@
 #include "cpr/cprtypes.h"
 #include "cpr/curlholder.h"
 #include "cpr/digest.h"
+#include "cpr/http_version.h"
 #include "cpr/interface.h"
 #include "cpr/limit_rate.h"
 #include "cpr/low_speed.h"
@@ -78,6 +79,7 @@ class Session {
     void SetDebugCallback(const DebugCallback& debug);
     void SetVerbose(const Verbose& verbose);
     void SetInterface(const Interface& iface);
+    void SetHttpVersion(const HttpVersion& version);
 
     // Used in templated functions
     void SetOption(const Url& url);
@@ -119,6 +121,7 @@ class Session {
     void SetOption(const UnixSocket& unix_socket);
     void SetOption(const SslOptions& options);
     void SetOption(const Interface& iface);
+    void SetOption(const HttpVersion& version);
 
     cpr_off_t GetDownloadFileLength();
     Response Delete();


### PR DESCRIPTION
Adds support for changing the HTTP(S) version to any of the ones currently provided by libcurl (https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html).

### Example:
```c++
cpr::Url url{server->GetBaseUrl() + "/header_reflect.html"};
cpr::Response response = cpr::Get(url, cpr::HttpVersion{cpr::HttpVersionCode::VERSION_2_0});
```

It supports the following values:
```c++
enum class HttpVersionCode {
    /**
     * Let libcurl decide which version is the best.
     **/
    VERSION_NONE,
    /**
     * Enforce HTTP 1.0 requests.
     **/
    VERSION_1_0,
    /**
     * Enforce HTTP 1.1 requests.
     **/
    VERSION_1_1,
#if LIBCURL_VERSION_NUM >= 0x072100 // 7.33.0
    /**
     * Attempt HTTP 2.0 requests.
     * Fallback to HTTP 1.1 if negotiation fails.
     **/
    VERSION_2_0,
#endif
#if LIBCURL_VERSION_NUM >= 0x072F00 // 7.47.0
    /**
     * Attempt HTTP 2.0 for HTTPS requests only.
     * Fallback to HTTP 1.1 if negotiation fails.
     * HTTP 1.1 will be used for HTTP connections.
     **/
    VERSION_2_0_TLS,
#endif
#if LIBCURL_VERSION_NUM >= 0x073100 // 7.49.0
    /**
     * Start HTTP 2.0 for HTTP requests.
     * Requires prior knowledge that the server supports HTTP 2.0.
     * For HTTPS requests we will negotiate the protocol version in the TLS handshake.
     **/
    VERSION_2_0_PRIOR_KNOWLEDGE,
#endif
#if LIBCURL_VERSION_NUM >= 0x074200 // 7.66.0
    /**
     * Attempt HTTP 3.0 requests.
     * Requires prior knowledge that the server supports HTTP 3.0 since there is no gracefully downgrade.
     * Fallback to HTTP 1.1 if negotiation fails.
     **/
    VERSION_3_0
#endif
};
```