### PR TITLE
Updating the package list before installing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libssl-dev
     - name: "[Release g++] Build & Test"
@@ -34,6 +36,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libssl-dev
     - name: Install clang-tidy
@@ -57,6 +61,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libssl-dev
     - name: "[Release g++] Build & Test"
@@ -78,6 +84,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libssl-dev
     - name: "[Release g++] Build & Test"
@@ -99,6 +107,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libssl-dev
     - name: "[Release g++] Build & Test"
@@ -120,6 +130,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libcurl4-openssl-dev
     - name: "[Release g++] Build & Test"
@@ -141,6 +153,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libcurl4-openssl-dev
     - name: "[Release g++] Build & Test"
@@ -162,6 +176,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libssl-dev
     - name: Install sanitizer
@@ -185,6 +201,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libssl-dev
     - name: Install sanitizer
@@ -207,6 +225,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libssl-dev
     - name: "[Release g++] Build & Test"
@@ -228,6 +248,8 @@ jobs:
       uses: actions/checkout@v2.2.0
       with:
         submodules: true
+    - name: Update package list
+      run: sudo apt update
     - name: Install libssl-dev
       run: sudo apt install libssl-dev
     - name: "[Release g++] Build & Test"


### PR DESCRIPTION
Running `sudo apt update` before `sudo apt install XYZ` in the CI to prevent outdated packages.
```bash
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  libcurl4-doc libidn11-dev libkrb5-dev libldap2-dev librtmp-dev libssh2-1-dev
The following NEW packages will be installed:
  libcurl4-openssl-dev
0 upgraded, 1 newly installed, 0 to remove and 14 not upgraded.
Need to get 301 kB of archives.
After this operation, 1426 kB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl4-openssl-dev amd64 7.58.0-2ubuntu3.14
Err:1 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl4-openssl-dev amd64 7.58.0-2ubuntu3.14
  404  Not Found [IP: 52.250.76.244 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.58.0-2ubuntu3.14_amd64.deb  404  Not Found [IP: 52.250.76.244 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```