### PR TITLE
Added support for an equivalent of CURL option `--location-trusted`

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -384,6 +384,7 @@ void Session::Impl::SetNTLM(const NTLM& auth) {
 void Session::Impl::SetRedirect(const Redirect& redirect) {
     curl_easy_setopt(curl_->handle, CURLOPT_FOLLOWLOCATION, redirect.follow ? 1L : 0L);
     curl_easy_setopt(curl_->handle, CURLOPT_MAXREDIRS, redirect.maximum);
+    curl_easy_setopt(curl_->handle, CURLOPT_UNRESTRICTED_AUTH, redirect.cont_send_cred ? 1L : 0L);
 
     // NOLINTNEXTLINE (google-runtime-int)
     long mask = 0;

--- a/include/cpr/redirect.h
+++ b/include/cpr/redirect.h
@@ -59,6 +59,12 @@ class Redirect {
      **/
     bool follow{true};
     /**
+     * Continue to send authentication (user+password) credentials when following locations, even when hostname changed.
+     * Default: false
+     * https://curl.se/libcurl/c/CURLOPT_UNRESTRICTED_AUTH.html
+     **/
+    bool cont_send_cred{false};
+    /**
      * Flags to control how to act after a redirect for a post request.
      * Default: POST_ALL
      **/
@@ -66,10 +72,11 @@ class Redirect {
 
     Redirect() = default;
     // NOLINTNEXTLINE (google-runtime-int)
-    Redirect(long p_maximum, bool p_follow, PostRedirectFlags p_post_flags) : maximum(p_maximum), follow(p_follow), post_flags(p_post_flags){};
+    Redirect(long p_maximum, bool p_follow, bool p_cont_send_cred, PostRedirectFlags p_post_flags) : maximum(p_maximum), follow(p_follow), cont_send_cred(p_cont_send_cred), post_flags(p_post_flags){};
     // NOLINTNEXTLINE (google-runtime-int)
     explicit Redirect(long p_maximum) : maximum(p_maximum){};
     explicit Redirect(bool p_follow) : follow(p_follow){};
+    Redirect(bool p_follow, bool p_cont_send_cred) : follow(p_follow), cont_send_cred(p_cont_send_cred){};
     explicit Redirect(PostRedirectFlags p_post_flags) : post_flags(p_post_flags){};
 };
 } // namespace cpr

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -5,6 +5,7 @@
 
 #include "cpr/cpr.h"
 #include "cpr/cprtypes.h"
+#include "cpr/redirect.h"
 #include "cpr/session.h"
 #include "httpServer.hpp"
 
@@ -1213,6 +1214,18 @@ TEST(GetRedirectTests, ZeroMaxRedirectsTest) {
     std::string expected_text{"Hello world!"};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(GetRedirectTests, BasicAuthenticationRedirectSuccessTest) {
+    Url url{server->GetBaseUrl() + "/temporary_redirect.html"};
+    Response response = cpr::Get(url, Authentication{"user", "password"}, Header{{"RedirectLocation", "basic_auth.html"}}, Redirect(true, true));
+    std::string expected_text{"Header reflect GET"};
+    EXPECT_EQ(expected_text, response.text);
+    std::string resultUrl = "http://user:password@127.0.0.1:" + std::to_string(server->GetPort()) + "/basic_auth.html";
+    EXPECT_EQ(response.url, resultUrl);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);


### PR DESCRIPTION
Adds an option for setting the equivalent of the CURL option `--location-trusted`.
In libcurl this is done by setting the `CURLOPT_UNRESTRICTED_AUTH` option.

For this I extended the `cpr::Redirect` with a new option `bool cont_send_cred{false};`.

```c++
cpr::Url url = "https://google.de";
cpr::Response response = cpr::Get(url, cpr::Authentication{"user", "password"}, cpr::Redirect(true, true));
```