### PR TITLE
CMake find-package support

### DIFF
--- a/cmake/cprConfig.cmake.in
+++ b/cmake/cprConfig.cmake.in
@@ -1,0 +1,8 @@
+include(CMakeFindDependencyMacro)
+@PACKAGE_INIT@
+
+find_dependency(CURL REQUIRED)
+
+include(${CMAKE_CURRENT_LIST_DIR}/cprTargets.cmake)
+
+check_required_components(cpr)

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -30,4 +30,31 @@ set_target_properties(cpr
      VERSION ${${PROJECT_NAME}_VERSION}
      SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR})
 
-install(TARGETS cpr)
+# Import GNU common install directory variables
+include(GNUInstallDirs)
+
+install(TARGETS cpr
+        EXPORT cprTargets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# Include CMake helpers for package config files
+# Follow this installation guideline: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+        "${CMAKE_BINARY_DIR}/cpr/cprConfigVersion.cmake"
+        VERSION ${${PROJECT_NAME}_VERSION}
+        COMPATIBILITY ExactVersion)
+
+configure_package_config_file(${CMAKE_SOURCE_DIR}/cmake/cprConfig.cmake.in
+                              "${CMAKE_BINARY_DIR}/cpr/cprConfig.cmake"
+                              INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cpr)
+
+install(EXPORT cprTargets
+        FILE cprTargets.cmake
+        NAMESPACE cpr::
+        DESTINATION lib/cmake/cpr)
+
+install(FILES ${CMAKE_BINARY_DIR}/cpr/cprConfig.cmake
+        ${CMAKE_BINARY_DIR}/cpr/cprConfigVersion.cmake DESTINATION lib/cmake/cpr)

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -30,11 +30,10 @@ set_target_properties(cpr
      VERSION ${${PROJECT_NAME}_VERSION}
      SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR})
 
+# Import GNU common install directory variables
+include(GNUInstallDirs)
 
 if(CPR_FORCE_USE_SYSTEM_CURL)
-    # Import GNU common install directory variables
-    include(GNUInstallDirs)
-
     install(TARGETS cpr
             EXPORT cprTargets
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -30,31 +30,38 @@ set_target_properties(cpr
      VERSION ${${PROJECT_NAME}_VERSION}
      SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR})
 
-# Import GNU common install directory variables
-include(GNUInstallDirs)
 
-install(TARGETS cpr
-        EXPORT cprTargets
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if(CPR_FORCE_USE_SYSTEM_CURL)
+    # Import GNU common install directory variables
+    include(GNUInstallDirs)
 
-# Include CMake helpers for package config files
-# Follow this installation guideline: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html
-include(CMakePackageConfigHelpers)
+    install(TARGETS cpr
+            EXPORT cprTargets
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-write_basic_package_version_file(
-        "${CMAKE_BINARY_DIR}/cpr/cprConfigVersion.cmake"
-        VERSION ${${PROJECT_NAME}_VERSION}
-        COMPATIBILITY ExactVersion)
+    # Include CMake helpers for package config files
+    # Follow this installation guideline: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html
+    include(CMakePackageConfigHelpers)
 
-configure_package_config_file(${CMAKE_SOURCE_DIR}/cmake/cprConfig.cmake.in
-                              "${CMAKE_BINARY_DIR}/cpr/cprConfig.cmake"
-                              INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cpr)
+    write_basic_package_version_file(
+            "${CMAKE_BINARY_DIR}/cpr/cprConfigVersion.cmake"
+            VERSION ${${PROJECT_NAME}_VERSION}
+            COMPATIBILITY ExactVersion)
 
-install(EXPORT cprTargets
-        FILE cprTargets.cmake
-        NAMESPACE cpr::
-        DESTINATION lib/cmake/cpr)
+    configure_package_config_file(${CMAKE_SOURCE_DIR}/cmake/cprConfig.cmake.in
+                                  "${CMAKE_BINARY_DIR}/cpr/cprConfig.cmake"
+                                  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cpr)
 
-install(FILES ${CMAKE_BINARY_DIR}/cpr/cprConfig.cmake
-        ${CMAKE_BINARY_DIR}/cpr/cprConfigVersion.cmake DESTINATION lib/cmake/cpr)
+    install(EXPORT cprTargets
+            FILE cprTargets.cmake
+            NAMESPACE cpr::
+            DESTINATION lib/cmake/cpr)
+
+    install(FILES ${CMAKE_BINARY_DIR}/cpr/cprConfig.cmake
+            ${CMAKE_BINARY_DIR}/cpr/cprConfigVersion.cmake DESTINATION lib/cmake/cpr)
+else()
+    install(TARGETS cpr
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()


### PR DESCRIPTION
This PR improves CMake integration of the library. 

I was surprised that one cannot simply download, build, install the library on the system and then simply integrate the library within other project via the standard CMake find-package utility. This PR adds this feature. For instance, now one can import the library in other CMake project like this:

**CMakeLists.txt**
```
cmake_minimum_required(VERSION 3.20)
project(cpr_client)

set(CMAKE_CXX_STANDARD 17)

find_package(cpr REQUIRED)
if (cpr_FOUND)
    message(STATUS "Found cpr: ${cpr_CONFIG} (found version ${cpr_VERSION})")
endif ()

add_executable(cpr_client main.cpp)

target_link_libraries(cpr_client PRIVATE cpr::cpr)
```

**main.cpp**
```cpp
#include <iostream>
#include <cpr/cpr.h>

int main(int argc, char** argv) {
    cpr::Response r = cpr::Get(cpr::Url{"https://api.github.com/repos/whoshuu/cpr/contributors"},
                               cpr::Authentication{"user", "pass"},
                               cpr::Parameters{{"anon", "true"}, {"key", "value"}});
    std::cout << r.status_code << std::endl;                  // 200
    std::cout << r.header["content-type"] << std::endl;;      // application/json; charset=utf-8
    std::cout << r.text << std::endl;                         // JSON text string
}
```

Note that I handle CURL dependency in cprConfig.cmake.in. This is why one has to only include `find_package(cpr REQUIRED)`. 

This feature is feasible only if *CPR_FORCE_USE_SYSTEM_CURL* is set. 
Otherwise, you download *libcurl* in-source and link against its targets.
This is a problem since you have to not only export and install cpr CMake target, but also all targets that cpr target links against.
In this case, *curl_int*. Further, its dependecies would have to be handled and exported, etc.
In other words, CMake is not a helpful tool for this use case.