### PR TITLE
Version macro

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(cpr PRIVATE
     cpr/interface.h
     cpr/redirect.h
     cpr/http_version.h
+    cpr/cprver.h
 )
 
 install(DIRECTORY cpr DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/include/cpr/cpr.h
+++ b/include/cpr/cpr.h
@@ -4,6 +4,7 @@
 #include "cpr/api.h"
 #include "cpr/auth.h"
 #include "cpr/cprtypes.h"
+#include "cpr/cprver.h"
 #include "cpr/http_version.h"
 #include "cpr/interface.h"
 #include "cpr/redirect.h"

--- a/include/cpr/cprver.h
+++ b/include/cpr/cprver.h
@@ -1,0 +1,30 @@
+#ifndef CPR_CPRVER_H
+#define CPR_CPRVER_H
+
+/**
+ * CPR version as a string.
+ **/
+#define CPR_VERSION "1.7.0"
+
+/**
+ * CPR version split up into parts.
+ **/
+#define CPR_VERSION_MAJOR 1
+#define CPR_VERSION_MINOR 7
+#define CPR_VERSION_PATCH 0
+
+/**
+ * CPR version as a single hex digit.
+ * it can be split up into three parts:
+ * 0xAABBCC
+ * AA: The current CPR major version number in a hex format.
+ * BB: The current CPR minor version number in a hex format.
+ * CC: The current CPR patch version number in a hex format.
+ *
+ * Examples:
+ * '0x010702' -> 01.07.02 -> CPR_VERSION: 1.7.2
+ * '0xA13722' -> A1.37.22 -> CPR_VERSION: 161.55.34
+ **/
+#define CPR_VERSION_NUM 0x010702
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ add_cpr_test(util)
 add_cpr_test(structures)
 add_cpr_test(encoded_auth)
 add_cpr_test(proxy_auth)
+add_cpr_test(version)
 
 if (ENABLE_SSL_TESTS)
     add_cpr_test(ssl)

--- a/test/version_tests.cpp
+++ b/test/version_tests.cpp
@@ -1,0 +1,65 @@
+#include <cctype>
+#include <cpr/cpr.h>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <string>
+
+
+TEST(VersionTests, StringVersionExists) {
+#ifndef CPR_VERSION
+    EXPECT_TRUE(false);
+#endif // CPR_VERSION
+}
+
+TEST(VersionTests, StringVersionValid) {
+    EXPECT_TRUE(CPR_VERSION != nullptr);
+    std::string version = CPR_VERSION;
+
+    // Check if the version string is: '\d+\.\d+\.\d+'
+    bool digit = true;
+    size_t dotCount = 0;
+    for (size_t i = 0; i < version.size(); i++) {
+        if (i == 0) {
+            EXPECT_TRUE(std::isdigit(version[i]));
+        } else if (digit) {
+            if (version[i] == '.') {
+                digit = false;
+                dotCount++;
+                continue;
+            }
+        }
+        EXPECT_TRUE(std::isdigit(version[i]));
+        digit = true;
+    }
+    EXPECT_EQ(dotCount, 2);
+}
+
+TEST(VersionTests, VersionMajorExists) {
+#ifndef CPR_VERSION_MAJOR
+    EXPECT_TRUE(false);
+#endif // CPR_VERSION_MAJOR
+}
+
+TEST(VersionTests, VersionMinorExists) {
+#ifndef CPR_VERSION_MINOR
+    EXPECT_TRUE(false);
+#endif // CPR_VERSION_MINOR
+}
+
+TEST(VersionTests, VersionPatchExists) {
+#ifndef CPR_VERSION_PATCH
+    EXPECT_TRUE(false);
+#endif // CPR_VERSION_PATCH
+}
+
+TEST(VersionTests, VersionNumExists) {
+#ifndef CPR_VERSION_NUM
+    EXPECT_TRUE(false);
+#endif // CPR_VERSION_NUM
+}
+
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Inspired by: https://github.com/rwinlib/libcurl/blob/v7.64.1/include/curl/curlver.h

Adds the following version macros to use:
```c++
/**
 * CPR version as a string.
 **/
#define CPR_VERSION "1.7.0"

/**
 * CPR version split up into parts.
 **/
#define CPR_VERSION_MAJOR 1
#define CPR_VERSION_MINOR 7
#define CPR_VERSION_PATCH 0

/**
 * CPR version as a single hex digit.
 * it can be split up into three parts:
 * 0xAABBCC
 * AA: The current CPR major version number in a hex format.
 * BB: The current CPR minor version number in a hex format.
 * CC: The current CPR patch version number in a hex format.
 *
 * Examples:
 * '0x010702' -> 01.07.02 -> CPR_VERSION: 1.7.2
 * '0xA13722' -> A1.37.22 -> CPR_VERSION: 161.55.34
 **/
#define CPR_VERSION_NUM 0x010702
```