### PR TITLE
Disable SSL options for curl build when CPR_ENABLE_SSL is off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,25 +176,28 @@ else()
     if (CPR_ENABLE_SSL)
         set(SSL_ENABLED ON CACHE INTERNAL "" FORCE)
         set(CURL_CA_PATH "auto" CACHE INTERNAL "" FORCE)
+
+        if(SSL_BACKEND_USED STREQUAL "WinSSL")
+            set(CMAKE_USE_SCHANNEL ON CACHE INTERNAL "" FORCE)
+        endif()
+
+        if(SSL_BACKEND_USED STREQUAL "OpenSSL")
+            set(CMAKE_USE_OPENSSL ON CACHE INTERNAL "" FORCE)
+        endif()
+
+        if(SSL_BACKEND_USED STREQUAL "DarwinSSL")
+            set(CMAKE_USE_SECTRANSP ON CACHE INTERNAL "" FORCE)
+        endif()
+
         message(STATUS "Enabled curl SSL")
     else()
         set(SSL_ENABLED OFF CACHE INTERNAL "" FORCE)
         set(CURL_CA_PATH "none" CACHE INTERNAL "" FORCE)
+        set(CMAKE_USE_SCHANNEL OFF CACHE INTERNAL "" FORCE)
+        set(CMAKE_USE_OPENSSL OFF CACHE INTERNAL "" FORCE)
+        set(CMAKE_USE_SECTRANSP OFF CACHE INTERNAL "" FORCE)
         message(STATUS "Disabled curl SSL")
     endif()
-
-    if(SSL_BACKEND_USED STREQUAL "WinSSL")
-        set(CMAKE_USE_SCHANNEL ON CACHE INTERNAL "" FORCE)
-    endif()
-
-    if(SSL_BACKEND_USED STREQUAL "OpenSSL")
-        set(CMAKE_USE_OPENSSL ON CACHE INTERNAL "" FORCE)
-    endif()
-
-    if(SSL_BACKEND_USED STREQUAL "DarwinSSL")
-        set(CMAKE_USE_SECTRANSP ON CACHE INTERNAL "" FORCE)
-    endif()
-
     # Disable linting for curl
     clear_variable(DESTINATION CMAKE_CXX_CLANG_TIDY BACKUP CMAKE_CXX_CLANG_TIDY_BKP)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CPR_LIBRARIES cpr CACHE INTERNAL "")
 macro(cpr_option OPTION_NAME OPTION_TEXT OPTION_DEFAULT)
     option(${OPTION_NAME} ${OPTION_TEXT} ${OPTION_DEFAULT})
     if(DEFINED ENV{${OPTION_NAME}})
-        # Allow setting the option through an environment variable
+        # Allow overriding the option through an environment variable
         set(${OPTION_NAME} $ENV{${OPTION_NAME}})
     endif()
     if(${OPTION_NAME})


### PR DESCRIPTION
This PR makes so that disabling SSL can be done by just setting `CPR_ENABLE_SSL` to off. The current behavior prior to this change is that to disable SSL, `CPR_ENABLE_SSL` needs to be set to off along with finding and setting the correct `CMAKE_USE_*` variable to off. An extended description is after the break/line.

I also changed a comment about using environment variables to control options, since the current behavior is overriding the value of an option, not actually setting the value for the option in the CMake cache (the changed value doesn't persist if a new shell gets opened, or the environment variable get unset).

---

With the way the curl build system is currently set up, the `SSL_ENABLED` variable is set based on the `CMAKE_USE_*` options and isn't used to determine if curl should be built with SSL support. It is also setting the `SSL_ENABLED` local variable, so whatever cpr is setting in the cache for `SSL_ENABLED` is effectively being ignored.

By default curl sets the `CMAKE_USE_OPENSSL` option to ON, so when `CPR_ENABLE_SSL` is set to OFF we also need to set `CMAKE_USE_OPENSSL` to OFF.

The other `CMAKE_USE_*` options are also set to OFF, since it makes the behavior a bit cleaner if a subsequent CMake configure disables the `CPR_ENABLE_SSL` option (no tracking down which `CMAKE_USE_*` option also needs disabling).