### PR TITLE
Use CMake libcpr version number to generate cprver.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
-project(cpr VERSION 1.6 LANGUAGES CXX)
+project(cpr VERSION 1.7.0 LANGUAGES CXX)
+
+math(EXPR cpr_VERSION_NUM "${cpr_VERSION_MAJOR} * 0x10000 + ${cpr_VERSION_MINOR} * 0x100 + ${cpr_VERSION_PATCH}" OUTPUT_FORMAT HEXADECIMAL)
+configure_file("${cpr_SOURCE_DIR}/cmake/cprver.h.in" "${cpr_BINARY_DIR}/cpr_generated_includes/cpr/cprver.h")
 
 # Only change the folder behaviour if cpr is not a subproject
 if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})

--- a/cmake/cprver.h.in
+++ b/cmake/cprver.h.in
@@ -4,14 +4,14 @@
 /**
  * CPR version as a string.
  **/
-#define CPR_VERSION "1.7.0"
+#define CPR_VERSION "${cpr_VERSION}"
 
 /**
  * CPR version split up into parts.
  **/
-#define CPR_VERSION_MAJOR 1
-#define CPR_VERSION_MINOR 7
-#define CPR_VERSION_PATCH 0
+#define CPR_VERSION_MAJOR ${cpr_VERSION_MAJOR}
+#define CPR_VERSION_MINOR ${cpr_VERSION_MINOR}
+#define CPR_VERSION_PATCH ${cpr_VERSION_PATCH}
 
 /**
  * CPR version as a single hex digit.
@@ -25,6 +25,6 @@
  * '0x010702' -> 01.07.02 -> CPR_VERSION: 1.7.2
  * '0xA13722' -> A1.37.22 -> CPR_VERSION: 161.55.34
  **/
-#define CPR_VERSION_NUM 0x010702
+#define CPR_VERSION_NUM ${cpr_VERSION_NUM}
 
 #endif

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.15)
 
 target_include_directories(cpr PUBLIC  
     $<INSTALL_INTERFACE:include>    
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/cpr_generated_includes/>)
 
 target_sources(cpr PRIVATE
      # Header files (useful in IDEs)
@@ -34,7 +35,8 @@ target_sources(cpr PRIVATE
     cpr/interface.h
     cpr/redirect.h
     cpr/http_version.h
-    cpr/cprver.h
+    ${PROJECT_BINARY_DIR}/cpr_generated_includes/cpr/cprver.h
 )
 
 install(DIRECTORY cpr DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY ${PROJECT_BINARY_DIR}/cpr_generated_includes/cpr DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
Here's an idea that builds on #649 and makes so that the cprver.h file is generated based on the version in the CMake project command -- this would make so the version number only needs updating in one place when it comes time to make a new release.

Thoughts/ideas/changes?