### PR TITLE
updated the conan example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ add_executable(${PROJECT_NAME} main.cpp)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake) # Include Conan-generated file
 conan_basic_setup(TARGETS) # Introduce Conan-generated targets
 
+# depending on your conan and cmake configuration, you may need to set the used ABI:
+# add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)  # uncomment/add this line if the build fails or you get a runtime error
+
 target_link_libraries(${PROJECT_NAME} CONAN_PKG::cpr)
 ```
 Create `conanfile.txt` in your source dir:


### PR DESCRIPTION
I needed to make an http client in c++ and I found this lib yesterday. The API is great, I tried it and kept getting an error using conan. It was frustrating and I thought of trying another lib. Today I opened an issue and give it another try, the solution was very simple and it was solved by adding ABI definition to my cmake setup.

I updated the conan example in the README to notify future users that this can be the issue. Instead of getting frustrated, users can uncomment that line responsible for the ABI config and try again.