### PR TITLE
use std::string_view for writecallback

### DIFF
--- a/include/cpr/callback.h
+++ b/include/cpr/callback.h
@@ -40,13 +40,13 @@ class WriteCallback {
   public:
     WriteCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    WriteCallback(std::function<bool(std::string data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
-    bool operator()(std::string data) const {
-        return callback(std::move(data), userdata);
+    WriteCallback(std::function<bool(std::string_view data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    bool operator()(std::string_view data) const {
+        return callback(data, userdata);
     }
 
     intptr_t userdata;
-    std::function<bool(std::string data, intptr_t userdata)> callback;
+    std::function<bool(std::string_view data, intptr_t userdata)> callback;
 };
 
 class ProgressCallback {


### PR DESCRIPTION
to avoid unnecessary memory allocations