### PR TITLE
[clang-tidy] don't default to warnings as errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,6 @@ Checks: '*,
 -llvmlibc-implementation-in-namespace,
 -llvmlibc-restrict-system-libc-headers
 '
-WarningsAsErrors: '*'
+WarningsAsErrors: ''
 HeaderFilterRegex: 'src/*.hpp'
 FormatStyle: file


### PR DESCRIPTION
I had issues with a new clang-tidy version (12), discovering new issues with the code, with cpr as a submodule. So the build of my project failed because clang-tidy uses the cpr .clang-tidy file.

I propose this change, since your CI runner [overrides](https://github.com/libcpr/cpr/blob/master/cmake/clang-tidy.cmake#L9) the setting anyway and this makes it integration/future proof, so projects using cpr as a submodule don't just fail because clang enhances clang-tidy with new features. :smirk: 


The generated error you probably want to investigate:
```
cpr/cpr/util.cpp:28:8: error: function 'parseHeader' has cognitive complexity of 31 (threshold 25) [readability-function-cognitive-complexity,-warnings-as-errors]
Header parseHeader(const std::string& headers, std::string* status_line, std::string* reason) {
       ^
cpr/cpr/util.cpp:34:9: note: +1, including nesting penalty of 0, nesting level increased to 1
        while (std::getline(stream, line, '\n')) {
        ^
cpr/cpr/util.cpp:39:5: note: +1, including nesting penalty of 0, nesting level increased to 1
    for (std::string& line : lines) {
    ^
```