### PR TITLE
Fix build with OpenSSL on Ubuntu bionic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ endif()
 # Curl configuration
 if(CPR_FORCE_USE_SYSTEM_CURL)
     if(CPR_ENABLE_SSL)
-        find_package(CURL COMPONENTS HTTP HTTPS SSL)
+        find_package(CURL COMPONENTS HTTP HTTPS)
         if(CURL_FOUND)
             message(STATUS "Curl ${CURL_VERSION_STRING} found on this system.")
             # To be able to load certificates under Windows when using OpenSSL:


### PR DESCRIPTION
Not sure why the `SSL` component is checked (seems superfluous compared to HTTPS), but this check does not work on Ubuntu bionic (cURL 7.58). As far as I can see, it can be removed safely, as long as the HTTPS check is retained.