### PR TITLE
KeyBlob introduced

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <functional>
 #include <stdexcept>
@@ -487,16 +488,35 @@ void Session::Impl::SetSslOptions(const SslOptions& options) {
             curl_easy_setopt(curl_->handle, CURLOPT_KEYPASSWD, options.key_pass.c_str());
         }
     } else if (!options.key_blob.empty()) {
-      struct curl_blob blob;
-      blob.data = const_cast<char *>(options.key_blob.c_str());
-      blob.len = options.key_blob.length();
-      curl_easy_setopt(curl_->handle, CURLOPT_SSLKEY_BLOB, &blob);
-      if (!options.key_type.empty()) {
-          curl_easy_setopt(curl_->handle, CURLOPT_SSLKEYTYPE, options.key_type.c_str());
-      }
-      if (!options.key_pass.empty()) {
-          curl_easy_setopt(curl_->handle, CURLOPT_KEYPASSWD, options.key_pass.c_str());
-      }
+        struct ScopedCharArray {
+            char* array;
+          #ifdef _WIN32
+            explicit ScopedCharArray(const std::string& init) : array(_strdup(init.c_str())) {}
+          #else
+            explicit ScopedCharArray(const std::string& init) : array(strdup(init.c_str())) {}
+          #endif // _WIN32
+            ScopedCharArray(const ScopedCharArray& array) = delete;
+            ScopedCharArray(const ScopedCharArray&& array) = delete;
+            ScopedCharArray operator = (const ScopedCharArray& obj) = delete;
+            ScopedCharArray operator = (const ScopedCharArray&& obj) = delete;
+            ~ScopedCharArray() {
+                // NOLINTNEXTLINE(cppcoreguidelines-no-malloc, hicpp-no-malloc)
+                free(array);
+                array = nullptr;
+            }
+        };
+
+        ScopedCharArray key_blob(options.key_blob);
+        curl_blob blob {};
+        blob.data = key_blob.array;
+        blob.len = options.key_blob.length();
+        curl_easy_setopt(curl_->handle, CURLOPT_SSLKEY_BLOB, &blob);
+        if (!options.key_type.empty()) {
+            curl_easy_setopt(curl_->handle, CURLOPT_SSLKEYTYPE, options.key_type.c_str());
+        }
+        if (!options.key_pass.empty()) {
+            curl_easy_setopt(curl_->handle, CURLOPT_KEYPASSWD, options.key_pass.c_str());
+        }
     }
     if (!options.pinned_public_key.empty()) {
         curl_easy_setopt(curl_->handle, CURLOPT_PINNEDPUBLICKEY, options.pinned_public_key.c_str());

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -488,28 +488,10 @@ void Session::Impl::SetSslOptions(const SslOptions& options) {
             curl_easy_setopt(curl_->handle, CURLOPT_KEYPASSWD, options.key_pass.c_str());
         }
     } else if (!options.key_blob.empty()) {
-        struct ScopedCharArray {
-            char* array;
-          #ifdef _WIN32
-            explicit ScopedCharArray(const std::string& init) : array(_strdup(init.c_str())) {}
-          #else
-            explicit ScopedCharArray(const std::string& init) : array(strdup(init.c_str())) {}
-          #endif // _WIN32
-            ScopedCharArray(const ScopedCharArray& array) = delete;
-            ScopedCharArray(const ScopedCharArray&& array) = delete;
-            ScopedCharArray operator = (const ScopedCharArray& obj) = delete;
-            ScopedCharArray operator = (const ScopedCharArray&& obj) = delete;
-            ~ScopedCharArray() {
-                // NOLINTNEXTLINE(cppcoreguidelines-no-malloc, hicpp-no-malloc)
-                free(array);
-                array = nullptr;
-            }
-        };
-
-        ScopedCharArray key_blob(options.key_blob);
+        std::string key_blob(options.key_blob);
         curl_blob blob {};
-        blob.data = key_blob.array;
-        blob.len = options.key_blob.length();
+        blob.data = &key_blob[0];
+        blob.len = key_blob.length();
         curl_easy_setopt(curl_->handle, CURLOPT_SSLKEY_BLOB, &blob);
         if (!options.key_type.empty()) {
             curl_easy_setopt(curl_->handle, CURLOPT_SSLKEYTYPE, options.key_type.c_str());

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -486,6 +486,17 @@ void Session::Impl::SetSslOptions(const SslOptions& options) {
         if (!options.key_pass.empty()) {
             curl_easy_setopt(curl_->handle, CURLOPT_KEYPASSWD, options.key_pass.c_str());
         }
+    } else if (!options.key_blob.empty()) {
+      struct curl_blob blob;
+      blob.data = const_cast<char *>(options.key_blob.c_str());
+      blob.len = options.key_blob.length();
+      curl_easy_setopt(curl_->handle, CURLOPT_SSLKEY_BLOB, &blob);
+      if (!options.key_type.empty()) {
+          curl_easy_setopt(curl_->handle, CURLOPT_SSLKEYTYPE, options.key_type.c_str());
+      }
+      if (!options.key_pass.empty()) {
+          curl_easy_setopt(curl_->handle, CURLOPT_KEYPASSWD, options.key_pass.c_str());
+      }
     }
     if (!options.pinned_public_key.empty()) {
         curl_easy_setopt(curl_->handle, CURLOPT_PINNEDPUBLICKEY, options.pinned_public_key.c_str());

--- a/include/cpr/ssl_options.h
+++ b/include/cpr/ssl_options.h
@@ -130,6 +130,25 @@ class KeyFile {
     }
 };
 
+class KeyBlob {
+  public:
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    KeyBlob(std::string&& p_blob) : blob(std::move(p_blob)) {}
+
+    template <typename BlobType, typename PassType>
+    KeyBlob(BlobType&& p_blob, PassType p_password)
+            : blob(std::forward<BlobType>(p_blob)), password(std::move(p_password)) {}
+
+    virtual ~KeyBlob() = default;
+
+    std::string blob;
+    std::string password;
+
+    virtual const char* GetKeyType() const {
+        return "PEM";
+    }
+};
+
 using PemKey = KeyFile;
 
 class DerKey : public KeyFile {
@@ -378,6 +397,7 @@ struct SslOptions {
     std::string cert_file;
     std::string cert_type;
     std::string key_file;
+    std::string key_blob;
     std::string key_type;
     std::string key_pass;
     std::string pinned_public_key;
@@ -414,6 +434,11 @@ struct SslOptions {
     }
     void SetOption(const ssl::KeyFile& opt) {
         key_file = opt.filename;
+        key_type = opt.GetKeyType();
+        key_pass = opt.password;
+    }
+    void SetOption(const ssl::KeyBlob& opt) {
+        key_blob = opt.blob;
         key_type = opt.GetKeyType();
         key_pass = opt.password;
     }


### PR DESCRIPTION
Options let to set an SSL private key using a path to a file only.
Such approach prevents against setting the private key, which is stored
in a secure storage and is extracted using an algorithm.

Patch introduces KeyBlob, which translates to the CURLOPT_SSLKEY_BLOB directly.
It can be set using SslOptions::SetOption(const ssl::KeyBlob&) API.
It is assumed that blob content is PEM.