### PR TITLE
75 - basic range support added

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -66,6 +66,7 @@ class Session::Impl {
     void SetSslOptions(const SslOptions& options);
     void SetInterface(const Interface& iface);
     void SetHttpVersion(const HttpVersion& version);
+    void SetRange(const Range& range);
 
     cpr_off_t GetDownloadFileLength();
     Response Delete();
@@ -537,6 +538,15 @@ void Session::Impl::SetSslOptions(const SslOptions& options) {
 #endif
 }
 
+void Session::Impl::SetRange(const Range &range) {
+    curl_off_t resume_from = range.resume_from;
+    curl_off_t finish_at = range.finish_at;
+    std::string range_str = std::to_string(resume_from) + "-" + std::to_string(finish_at);
+    curl_easy_setopt(curl_->handle, CURLOPT_RANGE, range_str.c_str());
+    curl_easy_setopt(curl_->handle, CURLOPT_RESUME_FROM_LARGE, resume_from);
+    curl_easy_setopt(curl_->handle, CURLOPT_INFILESIZE_LARGE, finish_at);
+}
+
 void Session::Impl::PrepareDelete() {
     curl_easy_setopt(curl_->handle, CURLOPT_HTTPGET, 0L);
     curl_easy_setopt(curl_->handle, CURLOPT_NOBODY, 0L);
@@ -661,6 +671,7 @@ Response Session::Impl::Post() {
 void Session::Impl::PreparePut() {
     curl_easy_setopt(curl_->handle, CURLOPT_NOBODY, 0L);
     curl_easy_setopt(curl_->handle, CURLOPT_CUSTOMREQUEST, "PUT");
+    curl_easy_setopt(curl_->handle, CURLOPT_RANGE, nullptr);
     prepareCommon();
 }
 
@@ -836,6 +847,7 @@ void Session::SetSslOptions(const SslOptions& options) { pimpl_->SetSslOptions(o
 void Session::SetVerbose(const Verbose& verbose) { pimpl_->SetVerbose(verbose); }
 void Session::SetInterface(const Interface& iface) { pimpl_->SetInterface(iface); }
 void Session::SetHttpVersion(const HttpVersion& version) { pimpl_->SetHttpVersion(version); }
+void Session::SetRange(const Range& range) { pimpl_->SetRange(range); }
 void Session::SetOption(const ReadCallback& read) { pimpl_->SetReadCallback(read); }
 void Session::SetOption(const HeaderCallback& header) { pimpl_->SetHeaderCallback(header); }
 void Session::SetOption(const WriteCallback& write) { pimpl_->SetWriteCallback(write); }
@@ -876,6 +888,7 @@ void Session::SetOption(const UnixSocket& unix_socket) { pimpl_->SetUnixSocket(u
 void Session::SetOption(const SslOptions& options) { pimpl_->SetSslOptions(options); }
 void Session::SetOption(const Interface& iface) { pimpl_->SetInterface(iface); }
 void Session::SetOption(const HttpVersion& version) { pimpl_->SetHttpVersion(version); }
+void Session::SetOption(const Range& range) { pimpl_->SetRange(range); }
 
 cpr_off_t Session::GetDownloadFileLength() { return pimpl_->GetDownloadFileLength(); }
 Response Session::Delete() { return pimpl_->Delete(); }

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -1,0 +1,19 @@
+#ifndef CPR_RANGE_H
+#define CPR_RANGE_H
+
+#include <cstdint>
+
+namespace cpr {
+
+class Range {
+  public:
+    Range(const std::int64_t p_resume_from, const std::int64_t p_finish_at)
+            : resume_from(p_resume_from), finish_at(p_finish_at) {}
+
+    std::int64_t resume_from = 0;
+    std::int64_t finish_at = 0;
+};
+
+} // namespace cpr
+
+#endif

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -25,6 +25,7 @@
 #include "cpr/proxies.h"
 #include "cpr/proxyauth.h"
 #include "cpr/redirect.h"
+#include "cpr/range.h"
 #include "cpr/response.h"
 #include "cpr/ssl_options.h"
 #include "cpr/timeout.h"
@@ -80,6 +81,7 @@ class Session {
     void SetVerbose(const Verbose& verbose);
     void SetInterface(const Interface& iface);
     void SetHttpVersion(const HttpVersion& version);
+    void SetRange(const Range& range);
 
     // Used in templated functions
     void SetOption(const Url& url);
@@ -122,6 +124,7 @@ class Session {
     void SetOption(const SslOptions& options);
     void SetOption(const Interface& iface);
     void SetOption(const HttpVersion& version);
+    void SetOption(const Range& range);
 
     cpr_off_t GetDownloadFileLength();
     Response Delete();

--- a/test/download_tests.cpp
+++ b/test/download_tests.cpp
@@ -29,6 +29,54 @@ TEST(DownloadTests, DownloadGzip) {
     EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
 }
 
+TEST(DownloadTests, RangeTestWholeFile) {
+#if 0
+    const int64_t download_size = 277186;
+    cpr::SslOptions sslOpts = cpr::Ssl(cpr::ssl::VerifyPeer{false}, cpr::ssl::VerifyHost{false}, cpr::ssl::VerifyStatus{false});
+    cpr::Url url{"https://curl.haxx.se/docs/manpage.html"};
+    cpr::Session session;
+    session.SetUrl(url);
+    session.SetRange(cpr::Range{0, -1});
+    session.SetSslOptions(sslOpts);
+    cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
+    EXPECT_EQ(download_size, response.downloaded_bytes);
+#endif
+}
+
+TEST(DownloadTests, RangeTestLowerLimit) {
+#if 0
+    const int64_t download_size = 277185;
+    cpr::SslOptions sslOpts = cpr::Ssl(cpr::ssl::VerifyPeer{false}, cpr::ssl::VerifyHost{false}, cpr::ssl::VerifyStatus{false});
+    cpr::Url url{"https://curl.haxx.se/docs/manpage.html"};
+    cpr::Session session;
+    session.SetUrl(url);
+    session.SetRange(cpr::Range{1, -1});
+    session.SetSslOptions(sslOpts);
+    cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
+    EXPECT_EQ(206, response.status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
+    EXPECT_EQ(download_size, response.downloaded_bytes);
+#endif
+}
+
+TEST(DownloadTests, RangeTestUpperLimit) {
+#if 0
+    const int64_t download_size = 128;
+    cpr::SslOptions sslOpts = cpr::Ssl(cpr::ssl::VerifyPeer{false}, cpr::ssl::VerifyHost{false}, cpr::ssl::VerifyStatus{false});
+    cpr::Url url{"https://curl.haxx.se/docs/manpage.html"};
+    cpr::Session session;
+    session.SetUrl(url);
+    session.SetRange(cpr::Range{0, download_size - 1});
+    session.SetSslOptions(sslOpts);
+    cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
+    EXPECT_EQ(206, response.status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
+    EXPECT_EQ(download_size, response.downloaded_bytes);
+#endif
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(server);

--- a/test/download_tests.cpp
+++ b/test/download_tests.cpp
@@ -30,51 +30,42 @@ TEST(DownloadTests, DownloadGzip) {
 }
 
 TEST(DownloadTests, RangeTestWholeFile) {
-#if 0
-    const int64_t download_size = 277186;
-    cpr::SslOptions sslOpts = cpr::Ssl(cpr::ssl::VerifyPeer{false}, cpr::ssl::VerifyHost{false}, cpr::ssl::VerifyStatus{false});
-    cpr::Url url{"https://curl.haxx.se/docs/manpage.html"};
+    const int64_t download_size = 9;
+    cpr::Url url{server->GetBaseUrl() + "/download_gzip.html"};
     cpr::Session session;
     session.SetUrl(url);
+    session.SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
     session.SetRange(cpr::Range{0, -1});
-    session.SetSslOptions(sslOpts);
     cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
     EXPECT_EQ(download_size, response.downloaded_bytes);
-#endif
 }
 
 TEST(DownloadTests, RangeTestLowerLimit) {
-#if 0
-    const int64_t download_size = 277185;
-    cpr::SslOptions sslOpts = cpr::Ssl(cpr::ssl::VerifyPeer{false}, cpr::ssl::VerifyHost{false}, cpr::ssl::VerifyStatus{false});
-    cpr::Url url{"https://curl.haxx.se/docs/manpage.html"};
+    const int64_t download_size = 8;
+    cpr::Url url{server->GetBaseUrl() + "/download_gzip.html"};
     cpr::Session session;
     session.SetUrl(url);
+    session.SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
     session.SetRange(cpr::Range{1, -1});
-    session.SetSslOptions(sslOpts);
     cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
     EXPECT_EQ(206, response.status_code);
     EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
     EXPECT_EQ(download_size, response.downloaded_bytes);
-#endif
 }
 
 TEST(DownloadTests, RangeTestUpperLimit) {
-#if 0
-    const int64_t download_size = 128;
-    cpr::SslOptions sslOpts = cpr::Ssl(cpr::ssl::VerifyPeer{false}, cpr::ssl::VerifyHost{false}, cpr::ssl::VerifyStatus{false});
-    cpr::Url url{"https://curl.haxx.se/docs/manpage.html"};
+    const int64_t download_size = 6;
+    cpr::Url url{server->GetBaseUrl() + "/download_gzip.html"};
     cpr::Session session;
     session.SetUrl(url);
+    session.SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
     session.SetRange(cpr::Range{0, download_size - 1});
-    session.SetSslOptions(sslOpts);
     cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
     EXPECT_EQ(206, response.status_code);
     EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
     EXPECT_EQ(download_size, response.downloaded_bytes);
-#endif
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Basic support for ranges. Tests are disabled as they are connecting to the cURL server, which supports range header. Tested with Download only.