### PR TITLE
Option to reserve space for the response string beforehand

### DIFF
--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -127,6 +127,17 @@ class Session {
     void SetOption(const Range& range);
 
     cpr_off_t GetDownloadFileLength();
+    /**
+     * Attempt to preallocate enough memory for specified number of characters in the response string.
+     * Pass 0 to disable this behavior and let the response string be allocated dynamically on demand.
+     *
+     * Example:
+     * cpr::Session session;
+     * session.SetUrl(cpr::Url{"http://xxx/file"});
+     * session.ResponseStringReserve(1024 * 512); // Reserve space for at least 1024 * 512 characters
+     * cpr::Response r = session.Get();
+     **/
+    void ResponseStringReserve(size_t size);
     Response Delete();
     Response Download(const WriteCallback& write);
     Response Download(std::ofstream& file);

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -905,7 +905,7 @@ TEST(BasicTests, ReserveResponseString) {
     Response response = session.Get();
     std::string expected_text{"Hello world!"};
     EXPECT_EQ(expected_text, response.text);
-    EXPECT_EQ(4096, response.text.capacity());
+    EXPECT_GE(response.text.capacity(), 4096);
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(200, response.status_code);

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -897,6 +897,21 @@ TEST(CurlHolderManipulateTests, CustomOptionTest) {
     }
 }
 
+TEST(BasicTests, ReserveResponseString) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    Session session;
+    session.SetUrl(url);
+    session.ResponseStringReserve(4096);
+    Response response = session.Get();
+    std::string expected_text{"Hello world!"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(4096, response.text.capacity());
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(server);


### PR DESCRIPTION
Closes #530

Example:
```c++
cpr::Session session;
session.SetUrl(cpr::Url{"http://xxx/file"});
session.ResponseStringReserve(1024 * 512); // Reserve space for at least 1024 * 512 characters
cpr::Response r = session.Get();
```