### PR TITLE
Not including curl.h in headers

### DIFF
--- a/include/cpr/cprtypes.h
+++ b/include/cpr/cprtypes.h
@@ -1,7 +1,7 @@
 #ifndef CPR_CPR_TYPES_H
 #define CPR_CPR_TYPES_H
 
-#include <curl/curl.h>
+#include <curl/system.h>
 #include <initializer_list>
 #include <map>
 #include <memory>

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -3,7 +3,6 @@
 
 #include <cassert>
 #include <cstdint>
-#include <curl/curl.h>
 #include <memory>
 #include <string>
 #include <utility>
@@ -41,8 +40,7 @@ class Response {
     long redirect_count{};
 
     Response() = default;
-    Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text, std::string&& p_header_string,
-             Cookies&& p_cookies, Error&& p_error);
+    Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text, std::string&& p_header_string, Cookies&& p_cookies, Error&& p_error);
     std::vector<std::string> GetCertInfo();
     Response(const Response& other) = default;
     Response(Response&& old) noexcept = default;


### PR DESCRIPTION
To prevent transitively including `windows.h` on windows when including `cpr.h` or `cprtypes.h`, `curl.h` includes got replaced or removed.

Fixes #700