### PR TITLE
Improve usability for ResponseStringReserve

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -68,6 +68,7 @@ class Session::Impl {
     void SetInterface(const Interface& iface);
     void SetHttpVersion(const HttpVersion& version);
     void SetRange(const Range& range);
+    void SetReserveSize(const ReserveSize& reserve_size);
 
     cpr_off_t GetDownloadFileLength();
     void ResponseStringReserve(size_t size);
@@ -562,6 +563,10 @@ void Session::Impl::SetRange(const Range& range) {
     curl_easy_setopt(curl_->handle, CURLOPT_INFILESIZE_LARGE, finish_at);
 }
 
+void Session::Impl::SetReserveSize(const ReserveSize& reserve_size) {
+    ResponseStringReserve(reserve_size.size);
+}
+
 void Session::Impl::PrepareDelete() {
     curl_easy_setopt(curl_->handle, CURLOPT_HTTPGET, 0L);
     curl_easy_setopt(curl_->handle, CURLOPT_NOBODY, 0L);
@@ -870,7 +875,7 @@ void Session::SetVerbose(const Verbose& verbose) { pimpl_->SetVerbose(verbose); 
 void Session::SetInterface(const Interface& iface) { pimpl_->SetInterface(iface); }
 void Session::SetHttpVersion(const HttpVersion& version) { pimpl_->SetHttpVersion(version); }
 void Session::SetRange(const Range& range) { pimpl_->SetRange(range); }
-void Session::SetReserveSize(const ReserveSize& reserve_size) { pimpl_->ResponseStringReserve(reserve_size.size); }
+void Session::SetReserveSize(const ReserveSize& reserve_size) { pimpl_->SetReserveSize(reserve_size); }
 void Session::SetOption(const ReadCallback& read) { pimpl_->SetReadCallback(read); }
 void Session::SetOption(const HeaderCallback& header) { pimpl_->SetHeaderCallback(header); }
 void Session::SetOption(const WriteCallback& write) { pimpl_->SetWriteCallback(write); }
@@ -912,7 +917,7 @@ void Session::SetOption(const SslOptions& options) { pimpl_->SetSslOptions(optio
 void Session::SetOption(const Interface& iface) { pimpl_->SetInterface(iface); }
 void Session::SetOption(const HttpVersion& version) { pimpl_->SetHttpVersion(version); }
 void Session::SetOption(const Range& range) { pimpl_->SetRange(range); }
-void Session::SetOption(const ReserveSize& reserve_size) { pimpl_->ResponseStringReserve(reserve_size.size); }
+void Session::SetOption(const ReserveSize& reserve_size) { pimpl_->SetReserveSize(reserve_size.size); }
 
 cpr_off_t Session::GetDownloadFileLength() { return pimpl_->GetDownloadFileLength(); }
 void Session::ResponseStringReserve(size_t size) { pimpl_->ResponseStringReserve(size); }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -870,6 +870,7 @@ void Session::SetVerbose(const Verbose& verbose) { pimpl_->SetVerbose(verbose); 
 void Session::SetInterface(const Interface& iface) { pimpl_->SetInterface(iface); }
 void Session::SetHttpVersion(const HttpVersion& version) { pimpl_->SetHttpVersion(version); }
 void Session::SetRange(const Range& range) { pimpl_->SetRange(range); }
+void Session::SetReserveSize(const ReserveSize& reserve_size) { pimpl_->ResponseStringReserve(reserve_size.size); }
 void Session::SetOption(const ReadCallback& read) { pimpl_->SetReadCallback(read); }
 void Session::SetOption(const HeaderCallback& header) { pimpl_->SetHeaderCallback(header); }
 void Session::SetOption(const WriteCallback& write) { pimpl_->SetWriteCallback(write); }
@@ -911,6 +912,7 @@ void Session::SetOption(const SslOptions& options) { pimpl_->SetSslOptions(optio
 void Session::SetOption(const Interface& iface) { pimpl_->SetInterface(iface); }
 void Session::SetOption(const HttpVersion& version) { pimpl_->SetHttpVersion(version); }
 void Session::SetOption(const Range& range) { pimpl_->SetRange(range); }
+void Session::SetOption(const ReserveSize& reserve_size) { pimpl_->ResponseStringReserve(reserve_size.size); }
 
 cpr_off_t Session::GetDownloadFileLength() { return pimpl_->GetDownloadFileLength(); }
 void Session::ResponseStringReserve(size_t size) { pimpl_->ResponseStringReserve(size); }

--- a/include/cpr/cpr.h
+++ b/include/cpr/cpr.h
@@ -25,6 +25,7 @@
 #include "cpr/proxyauth.h"
 #include "cpr/range.h"
 #include "cpr/redirect.h"
+#include "cpr/reserve_size.h"
 #include "cpr/response.h"
 #include "cpr/session.h"
 #include "cpr/ssl_options.h"

--- a/include/cpr/reserve_size.h
+++ b/include/cpr/reserve_size.h
@@ -1,0 +1,18 @@
+#ifndef CPR_RESERVE_SIZE_H
+#define CPR_RESERVE_SIZE_H
+
+#include <cstdint>
+
+namespace cpr {
+
+class ReserveSize {
+  public:
+      ReserveSize(const size_t _size)
+            : size(_size) {}
+
+    size_t size = 0;
+};
+
+} // namespace cpr
+
+#endif

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -24,8 +24,9 @@
 #include "cpr/payload.h"
 #include "cpr/proxies.h"
 #include "cpr/proxyauth.h"
-#include "cpr/redirect.h"
 #include "cpr/range.h"
+#include "cpr/redirect.h"
+#include "cpr/reserve_size.h"
 #include "cpr/response.h"
 #include "cpr/ssl_options.h"
 #include "cpr/timeout.h"
@@ -82,6 +83,7 @@ class Session {
     void SetInterface(const Interface& iface);
     void SetHttpVersion(const HttpVersion& version);
     void SetRange(const Range& range);
+    void SetReserveSize(const ReserveSize& reserve_size);
 
     // Used in templated functions
     void SetOption(const Url& url);
@@ -125,6 +127,7 @@ class Session {
     void SetOption(const Interface& iface);
     void SetOption(const HttpVersion& version);
     void SetOption(const Range& range);
+    void SetOption(const ReserveSize& reserve_size);
 
     cpr_off_t GetDownloadFileLength();
     /**

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -901,7 +901,7 @@ TEST(BasicTests, ReserveResponseString) {
     Url url{server->GetBaseUrl() + "/hello.html"};
     Session session;
     session.SetUrl(url);
-    session.ResponseStringReserve(4096);
+    session.SetReserveSize(4096);
     Response response = session.Get();
     std::string expected_text{"Hello world!"};
     EXPECT_EQ(expected_text, response.text);


### PR DESCRIPTION
The current interface for ResponseStringReserve doesn't allow `cpr::Get` and other similar functions to make use of it. The current implementation here is backwards compatible with previous versions, at the cost of making the current function redundant. Any feedback is appreciated.