### PR TITLE
Make sure mutex is properly initialized

### DIFF
--- a/cpr/curlholder.cpp
+++ b/cpr/curlholder.cpp
@@ -2,10 +2,6 @@
 #include <cassert>
 
 namespace cpr {
-// It does not make sense to make a std::mutex const.
-// NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
-std::mutex CurlHolder::curl_easy_init_mutex_{};
-
 CurlHolder::CurlHolder() {
     /**
      * Allow multithreaded access to CPR by locking curl_easy_init().
@@ -14,9 +10,9 @@ CurlHolder::CurlHolder() {
      * https://curl.haxx.se/libcurl/c/curl_easy_init.html
      * https://curl.haxx.se/libcurl/c/threadsafe.html
      **/
-    curl_easy_init_mutex_.lock();
+    curl_easy_init_mutex_().lock();
     handle = curl_easy_init();
-    curl_easy_init_mutex_.unlock();
+    curl_easy_init_mutex_().unlock();
 
     assert(handle);
 } // namespace cpr

--- a/include/cpr/curlholder.h
+++ b/include/cpr/curlholder.h
@@ -17,9 +17,12 @@ struct CurlHolder {
      * https://curl.haxx.se/libcurl/c/curl_easy_init.html
      * https://curl.haxx.se/libcurl/c/threadsafe.html
      **/
-    // It does not make sense to make a std::mutex const.
-    // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)    
-    static std::mutex curl_easy_init_mutex_;
+
+    // Avoids initalization order problems in a static build
+    static std::mutex& curl_easy_init_mutex_() {
+        static std::mutex curl_easy_init_mutex_;
+        return curl_easy_init_mutex_;
+    }
 
   public:
     CURL* handle{nullptr};


### PR DESCRIPTION
I encountered access violations in a static debug build included in a Windows DLL for another application. The mutex crashed on use due to not being initialized. This is avoidable by using an init function.