### PR TITLE
Downgraded curl to 1.80.0 to fix #709 and #732

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,19 +211,23 @@ else()
         endif()
 
         if(SSL_BACKEND_USED STREQUAL "WinSSL")
-            set(CURL_USE_SCHANNEL ON CACHE INTERNAL "" FORCE)
+            set(CURL_USE_SCHANNEL ON CACHE INTERNAL "" FORCE) # <= curl  1.80.0
+            set(CMAKE_USE_SCHANNEL ON CACHE INTERNAL "" FORCE) # > curl  1.80.0
         endif()
 
         if(SSL_BACKEND_USED STREQUAL "OpenSSL")
-            set(CURL_USE_OPENSSL ON CACHE INTERNAL "" FORCE)
+            set(CURL_USE_OPENSSL ON CACHE INTERNAL "" FORCE) # <= curl  1.80.0
+            set(CMAKE_USE_OPENSSL ON CACHE INTERNAL "" FORCE) # > curl  1.80.0
         endif()
 
         if(SSL_BACKEND_USED STREQUAL "DarwinSSL")
-            set(CURL_USE_SECTRANSP ON CACHE INTERNAL "" FORCE)
+            set(CURL_USE_SECTRANSP ON CACHE INTERNAL "" FORCE) # <= curl  1.80.0
+            set(CMAKE_USE_SECTRANSP ON CACHE INTERNAL "" FORCE) # > curl  1.80.0
         endif()
 
         if(SSL_BACKEND_USED STREQUAL "MbedTLS")
-            set(CURL_USE_MBEDTLS ON CACHE INTERNAL "" FORCE)
+            set(CURL_USE_MBEDTLS ON CACHE INTERNAL "" FORCE) # <= curl  1.80.0
+            set(CMAKE_USE_MBEDTLS ON CACHE INTERNAL "" FORCE) # > curl  1.80.0
         endif()
 
         message(STATUS "Enabled curl SSL")
@@ -240,8 +244,8 @@ else()
     clear_variable(DESTINATION CMAKE_CXX_CLANG_TIDY BACKUP CMAKE_CXX_CLANG_TIDY_BKP)
 
     FetchContent_Declare(curl
-                         URL                    https://github.com/curl/curl/releases/download/curl-7_81_0/curl-7.81.0.tar.xz
-                         URL_HASH               SHA256=a067b688d1645183febc31309ec1f3cdce9213d02136b6a6de3d50f69c95a7d3 # the file hash for curl-7.81.0.tar.xz
+                         URL                    https://github.com/curl/curl/releases/download/curl-7_80_0/curl-7.80.0.tar.xz
+                         URL_HASH               SHA256=a132bd93188b938771135ac7c1f3ac1d3ce507c1fcbef8c471397639214ae2ab # the file hash for curl-7.80.0.tar.xz
                          USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
     FetchContent_MakeAvailable(curl)
 


### PR DESCRIPTION
To fix HTTPS with DarwinSSL and WinSSL this PR downgrades curl to 1.80.0 while https://github.com/curl/curl/issues/8741 is being worked on.