### PR TITLE
clang-format CI and CI cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,29 +31,6 @@ jobs:
         ctest-options: -V
         configure-options: -DBUILD_SHARED_LIBS=ON
 
-  cppcheck:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Update package list
-      run: sudo apt update
-    - name: Install cppcheck
-      run: sudo apt install cppcheck
-    - name: "[Release g++] Build"
-      env:
-        CPR_ENABLE_CPPCHECK: ON
-      uses: ashutoshvarma/action-cmake-build@master
-      with:
-        build-dir: ${{github.workspace}}/build
-        source-dir: ${{github.workspace}}
-        cc: gcc
-        cxx: g++
-        build-type: Release
-        run-test: false
-
   ubuntu-20-static-gcc-mbedtls:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,33 +30,6 @@ jobs:
         run-test: true
         ctest-options: -V
         configure-options: -DBUILD_SHARED_LIBS=ON
-  
-  clang-tidy:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Update package list
-      run: sudo apt update
-    - name: Install libssl-dev
-      run: sudo apt install libssl-dev
-    - name: Install clang-tidy
-      run: sudo apt install clang-tidy
-    - name: "[Release g++] Build & Test"
-      env:
-        CPR_BUILD_TESTS: ON
-      uses: ashutoshvarma/action-cmake-build@master
-      with:
-        build-dir: ${{github.workspace}}/build
-        source-dir: ${{github.workspace}}
-        cc: clang
-        cxx: clang++
-        build-type: Release
-        run-test: true
-        ctest-options: -V
-        configure-options: -DCPR_ENABLE_LINTING=ON
 
   cppcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -6,5 +6,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-    uses: actions/checkout@v3
-    - uses: yshui/git-clang-format-lint@master
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Check format
+      uses: yshui/git-clang-format-lint@master

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,16 @@
+name: "Test Clang Format"
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.13
+      with:
+        source: '.'
+        extensions: 'c,h,cpp,hpp'
+        clangFormatVersion: 13
+        style: file

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -3,14 +3,8 @@ name: "Test Clang Format"
 on: [push]
 
 jobs:
-  build:
+  clang-format:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.13
-      with:
-        source: '.'
-        extensions: 'c,h,cpp,hpp'
-        clangFormatVersion: 13
-        style: file
+    uses: actions/checkout@v3
+    - uses: yshui/git-clang-format-lint@master

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,4 +9,4 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Check format
-      uses: yshui/git-clang-format-lint@master
+      uses: RafikFarhad/clang-format-github-action@v2.1.0

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,31 @@
+name: "Test Clang Tidy"
+
+on: [push]
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Update package list
+      run: sudo apt update
+    - name: Install libssl-dev
+      run: sudo apt install libssl-dev
+    - name: Install clang-tidy
+      run: sudo apt install clang-tidy
+    - name: "[Release g++] Build & Test"
+      env:
+        CPR_BUILD_TESTS: ON
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{github.workspace}}/build
+        source-dir: ${{github.workspace}}
+        cc: clang
+        cxx: clang++
+        build-type: Release
+        run-test: true
+        ctest-options: -V
+        configure-options: -DCPR_ENABLE_LINTING=ON

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,27 @@
+name: "Test cppcheck"
+
+on: [push]
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Update package list
+      run: sudo apt update
+    - name: Install cppcheck
+      run: sudo apt install cppcheck
+    - name: "[Release g++] Build"
+      env:
+        CPR_ENABLE_CPPCHECK: ON
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{github.workspace}}/build
+        source-dir: ${{github.workspace}}
+        cc: gcc
+        cxx: g++
+        build-type: Release
+        run-test: false

--- a/cpr/cprtypes.cpp
+++ b/cpr/cprtypes.cpp
@@ -5,8 +5,6 @@
 
 namespace cpr {
 bool CaseInsensitiveCompare::operator()(const std::string& a, const std::string& b) const noexcept {
-    return std::lexicographical_compare(
-            a.begin(), a.end(), b.begin(), b.end(),
-            [](unsigned char ac, unsigned char bc) { return std::tolower(ac) < std::tolower(bc); });
+    return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), [](unsigned char ac, unsigned char bc) { return std::tolower(ac) < std::tolower(bc); });
 }
 } // namespace cpr

--- a/cpr/curl_container.cpp
+++ b/cpr/curl_container.cpp
@@ -5,8 +5,7 @@
 
 namespace cpr {
 template <class T>
-CurlContainer<T>::CurlContainer(const std::initializer_list<T>& containerList)
-        : containerList_(containerList) {}
+CurlContainer<T>::CurlContainer(const std::initializer_list<T>& containerList) : containerList_(containerList) {}
 
 template <class T>
 void CurlContainer<T>::Add(const std::initializer_list<T>& containerList) {

--- a/cpr/proxies.cpp
+++ b/cpr/proxies.cpp
@@ -7,8 +7,7 @@
 
 namespace cpr {
 
-Proxies::Proxies(const std::initializer_list<std::pair<const std::string, std::string>>& hosts)
-        : hosts_{hosts} {}
+Proxies::Proxies(const std::initializer_list<std::pair<const std::string, std::string>>& hosts) : hosts_{hosts} {}
 
 bool Proxies::has(const std::string& protocol) const {
     return hosts_.count(protocol) > 0;

--- a/cpr/response.cpp
+++ b/cpr/response.cpp
@@ -1,11 +1,7 @@
 #include "cpr/response.h"
 
 namespace cpr {
-Response::Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text,
-                   std::string&& p_header_string, Cookies&& p_cookies = Cookies{},
-                   Error&& p_error = Error{})
-        : curl_(std::move(curl)), text(std::move(p_text)), cookies(std::move(p_cookies)),
-          error(std::move(p_error)), raw_header(std::move(p_header_string)) {
+Response::Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text, std::string&& p_header_string, Cookies&& p_cookies = Cookies{}, Error&& p_error = Error{}) : curl_(std::move(curl)), text(std::move(p_text)), cookies(std::move(p_cookies)), error(std::move(p_error)), raw_header(std::move(p_header_string)) {
     header = cpr::util::parseHeader(raw_header, &status_line, &reason);
     assert(curl_);
     assert(curl_->handle);

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -116,17 +116,14 @@ size_t writeUserFunction(char* ptr, size_t size, size_t nmemb, const WriteCallba
 }
 
 #if LIBCURL_VERSION_NUM < 0x072000
-int progressUserFunction(const ProgressCallback* progress, double dltotal, double dlnow,
-                         double ultotal, double ulnow) {
+int progressUserFunction(const ProgressCallback* progress, double dltotal, double dlnow, double ultotal, double ulnow) {
 #else
-int progressUserFunction(const ProgressCallback* progress, curl_off_t dltotal, curl_off_t dlnow,
-                         curl_off_t ultotal, curl_off_t ulnow) {
+int progressUserFunction(const ProgressCallback* progress, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
 #endif
     return (*progress)(dltotal, dlnow, ultotal, ulnow) ? 0 : 1;
 }
 
-int debugUserFunction(CURL* /*handle*/, curl_infotype type, char* data, size_t size,
-                      const DebugCallback* debug) {
+int debugUserFunction(CURL* /*handle*/, curl_infotype type, char* data, size_t size, const DebugCallback* debug) {
     (*debug)(DebugCallback::InfoType(type), std::string(data, size));
     return 0;
 }

--- a/include/cpr/api.h
+++ b/include/cpr/api.h
@@ -26,8 +26,8 @@ namespace priv {
 
 template <typename... Ts>
 void set_option(Session& session, Ts&&... ts) {
-    std::initializer_list<int> ignore = { (session.SetOption(std::forward<Ts>(ts)), 0)... };
-    (void)ignore;
+    std::initializer_list<int> ignore = {(session.SetOption(std::forward<Ts>(ts)), 0)...};
+    (void) ignore;
 }
 
 } // namespace priv
@@ -52,8 +52,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto GetCallback(Then then, Ts... ts) -> std::future<decltype(then(Get(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Get(std::move(ts_inner)...)); },
-            std::move(then), std::move(ts)...);
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Get(std::move(ts_inner)...)); }, std::move(then), std::move(ts)...);
 }
 
 // Post methods
@@ -76,8 +75,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto PostCallback(Then then, Ts... ts) -> std::future<decltype(then(Post(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Post(std::move(ts_inner)...)); },
-            std::move(then), std::move(ts)...);
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Post(std::move(ts_inner)...)); }, std::move(then), std::move(ts)...);
 }
 
 // Put methods
@@ -100,8 +98,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto PutCallback(Then then, Ts... ts) -> std::future<decltype(then(Put(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Put(std::move(ts_inner)...)); },
-            std::move(then), std::move(ts)...);
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Put(std::move(ts_inner)...)); }, std::move(then), std::move(ts)...);
 }
 
 // Head methods
@@ -124,8 +121,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto HeadCallback(Then then, Ts... ts) -> std::future<decltype(then(Head(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Head(std::move(ts_inner)...)); },
-            std::move(then), std::move(ts)...);
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Head(std::move(ts_inner)...)); }, std::move(then), std::move(ts)...);
 }
 
 // Delete methods
@@ -140,8 +136,7 @@ Response Delete(Ts&&... ts) {
 template <typename... Ts>
 AsyncResponse DeleteAsync(Ts... ts) {
     return std::async(
-            std::launch::async, [](Ts... ts_inner) { return Delete(std::move(ts_inner)...); },
-            std::move(ts)...);
+            std::launch::async, [](Ts... ts_inner) { return Delete(std::move(ts_inner)...); }, std::move(ts)...);
 }
 
 // Delete callback methods
@@ -149,8 +144,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto DeleteCallback(Then then, Ts... ts) -> std::future<decltype(then(Delete(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Delete(std::move(ts_inner)...)); },
-            std::move(then), std::move(ts)...);
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Delete(std::move(ts_inner)...)); }, std::move(then), std::move(ts)...);
 }
 
 // Options methods
@@ -165,18 +159,15 @@ Response Options(Ts&&... ts) {
 template <typename... Ts>
 AsyncResponse OptionsAsync(Ts... ts) {
     return std::async(
-            std::launch::async, [](Ts... ts_inner) { return Options(std::move(ts_inner)...); },
-            std::move(ts)...);
+            std::launch::async, [](Ts... ts_inner) { return Options(std::move(ts_inner)...); }, std::move(ts)...);
 }
 
 // Options callback methods
 template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
-auto OptionsCallback(Then then, Ts... ts)
-        -> std::future<decltype(then(Options(std::move(ts)...)))> {
+auto OptionsCallback(Then then, Ts... ts) -> std::future<decltype(then(Options(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Options(std::move(ts_inner)...)); },
-            std::move(then), std::move(ts)...);
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Options(std::move(ts_inner)...)); }, std::move(then), std::move(ts)...);
 }
 
 // Patch methods
@@ -199,8 +190,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto PatchCallback(Then then, Ts... ts) -> std::future<decltype(then(Patch(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Patch(std::move(ts_inner)...)); },
-            std::move(then), std::move(ts)...);
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Patch(std::move(ts_inner)...)); }, std::move(then), std::move(ts)...);
 }
 
 // Download methods
@@ -215,10 +205,12 @@ Response Download(std::ofstream& file, Ts&&... ts) {
 template <typename... Ts>
 AsyncResponse DownloadAsync(std::string local_path, Ts... ts) {
     return std::async(
-            std::launch::async, [](std::string local_path, Ts... ts) {
+            std::launch::async,
+            [](std::string local_path, Ts... ts) {
                 std::ofstream f(local_path);
                 return Download(f, std::move(ts)...);
-            }, std::move(local_path), std::move(ts)...);
+            },
+            std::move(local_path), std::move(ts)...);
 }
 
 // Download with user callback

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -9,10 +9,8 @@ namespace cpr {
 
 class Authentication {
   public:
-    Authentication(const std::string& username, const std::string& password)
-            : auth_string_{username + ":" + password} {}
-    Authentication(std::string&& username, std::string&& password)
-            : auth_string_{std::move(username) + ":" + std::move(password)} {}
+    Authentication(const std::string& username, const std::string& password) : auth_string_{username + ":" + password} {}
+    Authentication(std::string&& username, std::string&& password) : auth_string_{std::move(username) + ":" + std::move(password)} {}
     Authentication(const Authentication& other) = default;
     Authentication(Authentication&& old) noexcept = default;
     virtual ~Authentication() noexcept = default;

--- a/include/cpr/bearer.h
+++ b/include/cpr/bearer.h
@@ -1,8 +1,8 @@
 #ifndef CPR_BEARER_H
 #define CPR_BEARER_H
 
-#include <string>
 #include <curl/curlver.h>
+#include <string>
 
 #include <utility>
 

--- a/include/cpr/cookies.h
+++ b/include/cpr/cookies.h
@@ -26,12 +26,9 @@ class Cookies {
 
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     Cookies(bool p_encode = true) : encode(p_encode) {}
-    Cookies(const std::initializer_list<std::pair<const std::string, std::string>>& pairs,
-            bool p_encode = true)
-            : encode(p_encode), map_{pairs} {}
+    Cookies(const std::initializer_list<std::pair<const std::string, std::string>>& pairs, bool p_encode = true) : encode(p_encode), map_{pairs} {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Cookies(const std::map<std::string, std::string>& map, bool p_encode = true)
-            : encode(p_encode), map_{map} {}
+    Cookies(const std::map<std::string, std::string>& map, bool p_encode = true) : encode(p_encode), map_{map} {}
 
     std::string& operator[](const std::string& key);
     std::string GetEncoded(const CurlHolder& holder) const;

--- a/include/cpr/curl_container.h
+++ b/include/cpr/curl_container.h
@@ -13,8 +13,7 @@ namespace cpr {
 
 struct Parameter {
     Parameter(const std::string& p_key, const std::string& p_value) : key{p_key}, value{p_value} {}
-    Parameter(std::string&& p_key, std::string&& p_value)
-            : key{std::move(p_key)}, value{std::move(p_value)} {}
+    Parameter(std::string&& p_key, std::string&& p_value) : key{std::move(p_key)}, value{std::move(p_value)} {}
 
     std::string key;
     std::string value;
@@ -22,8 +21,7 @@ struct Parameter {
 
 struct Pair {
     Pair(const std::string& p_key, const std::string& p_value) : key(p_key), value(p_value) {}
-    Pair(std::string&& p_key, std::string&& p_value)
-            : key(std::move(p_key)), value(std::move(p_value)) {}
+    Pair(std::string&& p_key, std::string&& p_value) : key(std::move(p_key)), value(std::move(p_value)) {}
 
     std::string key;
     std::string value;

--- a/include/cpr/digest.h
+++ b/include/cpr/digest.h
@@ -6,8 +6,7 @@
 namespace cpr {
 class Digest : public Authentication {
   public:
-    Digest(const std::string& username, const std::string& password)
-            : Authentication{username, password} {}
+    Digest(const std::string& username, const std::string& password) : Authentication{username, password} {}
 };
 
 } // namespace cpr

--- a/include/cpr/limit_rate.h
+++ b/include/cpr/limit_rate.h
@@ -7,8 +7,7 @@ namespace cpr {
 
 class LimitRate {
   public:
-    LimitRate(const std::int64_t p_downrate, const std::int64_t p_uprate)
-            : downrate(p_downrate), uprate(p_uprate) {}
+    LimitRate(const std::int64_t p_downrate, const std::int64_t p_uprate) : downrate(p_downrate), uprate(p_uprate) {}
 
     std::int64_t downrate = 0;
     std::int64_t uprate = 0;

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -23,17 +23,13 @@ struct Buffer {
             // Ignored here since libcurl reqires a long.
             // There is also no way around the reinterpret_cast.
             // NOLINTNEXTLINE(google-runtime-int, cppcoreguidelines-pro-type-reinterpret-cast)
-            : data{reinterpret_cast<data_t>(&(*begin))}, datalen{static_cast<long>(
-                                                            std::distance(begin, end))},
-              filename(std::move(p_filename)) {
+            : data{reinterpret_cast<data_t>(&(*begin))}, datalen{static_cast<long>(std::distance(begin, end))}, filename(std::move(p_filename)) {
         is_random_access_iterator(begin, end);
         static_assert(sizeof(*begin) == 1, "only byte buffers can be used");
     }
 
     template <typename Iterator>
-    typename std::enable_if<std::is_same<typename std::iterator_traits<Iterator>::iterator_category,
-                                         std::random_access_iterator_tag>::value>::type
-    is_random_access_iterator(Iterator /* begin */, Iterator /* end */) {}
+    typename std::enable_if<std::is_same<typename std::iterator_traits<Iterator>::iterator_category, std::random_access_iterator_tag>::value>::type is_random_access_iterator(Iterator /* begin */, Iterator /* end */) {}
 
     data_t data;
     // Ignored here since libcurl reqires a long:
@@ -43,18 +39,10 @@ struct Buffer {
 };
 
 struct Part {
-    Part(const std::string& p_name, const std::string& p_value, const std::string& p_content_type = {})
-            : name{p_name}, value{p_value},
-              content_type{p_content_type}, is_file{false}, is_buffer{false} {}
-    Part(const std::string& p_name, const std::int32_t& p_value, const std::string& p_content_type = {})
-            : name{p_name}, value{std::to_string(p_value)},
-              content_type{p_content_type}, is_file{false}, is_buffer{false} {}
-    Part(const std::string& p_name, const File& file, const std::string& p_content_type = {})
-            : name{p_name}, value{file.filepath},
-              content_type{p_content_type}, is_file{true}, is_buffer{false} {}
-    Part(const std::string& p_name, const Buffer& buffer, const std::string& p_content_type = {})
-            : name{p_name}, value{buffer.filename}, content_type{p_content_type}, data{buffer.data},
-              datalen{buffer.datalen}, is_file{false}, is_buffer{true} {}
+    Part(const std::string& p_name, const std::string& p_value, const std::string& p_content_type = {}) : name{p_name}, value{p_value}, content_type{p_content_type}, is_file{false}, is_buffer{false} {}
+    Part(const std::string& p_name, const std::int32_t& p_value, const std::string& p_content_type = {}) : name{p_name}, value{std::to_string(p_value)}, content_type{p_content_type}, is_file{false}, is_buffer{false} {}
+    Part(const std::string& p_name, const File& file, const std::string& p_content_type = {}) : name{p_name}, value{file.filepath}, content_type{p_content_type}, is_file{true}, is_buffer{false} {}
+    Part(const std::string& p_name, const Buffer& buffer, const std::string& p_content_type = {}) : name{p_name}, value{buffer.filename}, content_type{p_content_type}, data{buffer.data}, datalen{buffer.datalen}, is_file{false}, is_buffer{true} {}
 
     std::string name;
     std::string value;

--- a/include/cpr/ntlm.h
+++ b/include/cpr/ntlm.h
@@ -6,8 +6,7 @@
 namespace cpr {
 class NTLM : public Authentication {
   public:
-    NTLM(const std::string& username, const std::string& password)
-            : Authentication{username, password} {}
+    NTLM(const std::string& username, const std::string& password) : Authentication{username, password} {}
 };
 
 } // namespace cpr

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -7,8 +7,7 @@ namespace cpr {
 
 class Range {
   public:
-    Range(const std::int64_t p_resume_from, const std::int64_t p_finish_at)
-            : resume_from(p_resume_from), finish_at(p_finish_at) {}
+    Range(const std::int64_t p_resume_from, const std::int64_t p_finish_at) : resume_from(p_resume_from), finish_at(p_finish_at) {}
 
     std::int64_t resume_from = 0;
     std::int64_t finish_at = 0;

--- a/include/cpr/reserve_size.h
+++ b/include/cpr/reserve_size.h
@@ -7,8 +7,7 @@ namespace cpr {
 
 class ReserveSize {
   public:
-      ReserveSize(const size_t _size)
-            : size(_size) {}
+    ReserveSize(const size_t _size) : size(_size) {}
 
     size_t size = 0;
 };

--- a/include/cpr/ssl_options.h
+++ b/include/cpr/ssl_options.h
@@ -7,12 +7,8 @@
 
 #include <utility>
 
-#define __LIBCURL_VERSION_GTE(major, minor) \
-    ((LIBCURL_VERSION_MAJOR > (major)) ||   \
-     ((LIBCURL_VERSION_MAJOR == (major)) && (LIBCURL_VERSION_MINOR >= (minor))))
-#define __LIBCURL_VERSION_LT(major, minor) \
-    ((LIBCURL_VERSION_MAJOR < (major)) ||  \
-     ((LIBCURL_VERSION_MAJOR == (major)) && (LIBCURL_VERSION_MINOR < (minor))))
+#define __LIBCURL_VERSION_GTE(major, minor) ((LIBCURL_VERSION_MAJOR > (major)) || ((LIBCURL_VERSION_MAJOR == (major)) && (LIBCURL_VERSION_MINOR >= (minor))))
+#define __LIBCURL_VERSION_LT(major, minor) ((LIBCURL_VERSION_MAJOR < (major)) || ((LIBCURL_VERSION_MAJOR == (major)) && (LIBCURL_VERSION_MINOR < (minor))))
 
 #ifndef SUPPORT_ALPN
 #define SUPPORT_ALPN __LIBCURL_VERSION_GTE(7, 36)
@@ -117,8 +113,7 @@ class KeyFile {
     KeyFile(std::string&& p_filename) : filename(std::move(p_filename)) {}
 
     template <typename FileType, typename PassType>
-    KeyFile(FileType&& p_filename, PassType p_password)
-            : filename(std::forward<FileType>(p_filename)), password(std::move(p_password)) {}
+    KeyFile(FileType&& p_filename, PassType p_password) : filename(std::forward<FileType>(p_filename)), password(std::move(p_password)) {}
 
     virtual ~KeyFile() = default;
 
@@ -136,8 +131,7 @@ class KeyBlob {
     KeyBlob(std::string&& p_blob) : blob(std::move(p_blob)) {}
 
     template <typename BlobType, typename PassType>
-    KeyBlob(BlobType&& p_blob, PassType p_password)
-            : blob(std::forward<BlobType>(p_blob)), password(std::move(p_password)) {}
+    KeyBlob(BlobType&& p_blob, PassType p_password) : blob(std::forward<BlobType>(p_blob)), password(std::move(p_password)) {}
 
     virtual ~KeyBlob() = default;
 
@@ -157,8 +151,7 @@ class DerKey : public KeyFile {
     DerKey(std::string&& p_filename) : KeyFile(std::move(p_filename)) {}
 
     template <typename FileType, typename PassType>
-    DerKey(FileType&& p_filename, PassType p_password)
-            : KeyFile(std::forward<FileType>(p_filename), std::move(p_password)) {}
+    DerKey(FileType&& p_filename, PassType p_password) : KeyFile(std::forward<FileType>(p_filename), std::move(p_password)) {}
 
     virtual ~DerKey() = default;
 
@@ -379,7 +372,7 @@ class SslFastStart {
 #endif
 
 class NoRevoke {
-public:
+  public:
     NoRevoke() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     NoRevoke(bool p_enabled) : enabled(p_enabled) {}

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -13,8 +13,7 @@
 namespace cpr {
 namespace util {
 
-Header parseHeader(const std::string& headers, std::string* status_line = nullptr,
-                   std::string* reason = nullptr);
+Header parseHeader(const std::string& headers, std::string* status_line = nullptr, std::string* reason = nullptr);
 Cookies parseCookies(curl_slist* raw_cookies);
 size_t readUserFunction(char* ptr, size_t size, size_t nitems, const ReadCallback* read);
 size_t headerUserFunction(char* ptr, size_t size, size_t nmemb, const HeaderCallback* header);
@@ -22,14 +21,11 @@ size_t writeFunction(char* ptr, size_t size, size_t nmemb, std::string* data);
 size_t writeFileFunction(char* ptr, size_t size, size_t nmemb, std::ofstream* file);
 size_t writeUserFunction(char* ptr, size_t size, size_t nmemb, const WriteCallback* write);
 #if LIBCURL_VERSION_NUM < 0x072000
-int progressUserFunction(const ProgressCallback* progress, double dltotal, double dlnow,
-                         double ultotal, double ulnow);
+int progressUserFunction(const ProgressCallback* progress, double dltotal, double dlnow, double ultotal, double ulnow);
 #else
-int progressUserFunction(const ProgressCallback* progress, curl_off_t dltotal, curl_off_t dlnow,
-                         curl_off_t ultotal, curl_off_t ulnow);
+int progressUserFunction(const ProgressCallback* progress, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
 #endif
-int debugUserFunction(CURL* handle, curl_infotype type, char* data, size_t size,
-                      const DebugCallback* debug);
+int debugUserFunction(CURL* handle, curl_infotype type, char* data, size_t size, const DebugCallback* debug);
 std::vector<std::string> split(const std::string& to_split, char delimiter);
 std::string urlEncode(const std::string& s);
 std::string urlDecode(const std::string& s);

--- a/test/abstractServer.hpp
+++ b/test/abstractServer.hpp
@@ -38,8 +38,7 @@ class AbstractServer : public testing::Environment {
     void Run();
 
   protected:
-    virtual mg_connection* initServer(mg_mgr* mgr,
-                                      MG_CB(mg_event_handler_t event_handler, void* user_data)) = 0;
+    virtual mg_connection* initServer(mg_mgr* mgr, MG_CB(mg_event_handler_t event_handler, void* user_data)) = 0;
 
     static std::string Base64Decode(const std::string& in);
 };

--- a/test/async_tests.cpp
+++ b/test/async_tests.cpp
@@ -64,12 +64,7 @@ TEST(UrlEncodedPostTests, AsyncGetMultipleReflectTest) {
 
 TEST(UrlEncodedPostTests, AsyncDownloadTest) {
     cpr::Url url{server->GetBaseUrl() + "/download_gzip.html"};
-    cpr::AsyncResponse future = cpr::DownloadAsync(
-        "/tmp/aync_download",
-        url,
-        cpr::Header{{"Accept-Encoding", "gzip"}},
-        cpr::WriteCallback{write_data, 0}
-    );
+    cpr::AsyncResponse future = cpr::DownloadAsync("/tmp/aync_download", url, cpr::Header{{"Accept-Encoding", "gzip"}}, cpr::WriteCallback{write_data, 0});
     cpr::Response response = future.get();
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(200, response.status_code);

--- a/test/delete_tests.cpp
+++ b/test/delete_tests.cpp
@@ -34,8 +34,7 @@ TEST(DeleteTests, DeleteUnallowedTest) {
 
 TEST(DeleteTests, DeleteJsonBodyTest) {
     Url url{server->GetBaseUrl() + "/delete.html"};
-    Response response = cpr::Delete(url, cpr::Body{"'foo': 'bar'"},
-                                    cpr::Header{{"Content-Type", "application/json"}});
+    Response response = cpr::Delete(url, cpr::Body{"'foo': 'bar'"}, cpr::Header{{"Content-Type", "application/json"}});
     std::string expected_text{"'foo': 'bar'"};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);

--- a/test/error_tests.cpp
+++ b/test/error_tests.cpp
@@ -46,8 +46,7 @@ TEST(ErrorTests, ConnectTimeoutFailure) {
     Response response = cpr::Get(url, cpr::ConnectTimeout{1});
     EXPECT_EQ(0, response.status_code);
     // Sometimes a CONNECTION_FAILURE happens before the OPERATION_TIMEDOUT:
-    EXPECT_TRUE(response.error.code == ErrorCode::OPERATION_TIMEDOUT ||
-                response.error.code == ErrorCode::CONNECTION_FAILURE);
+    EXPECT_TRUE(response.error.code == ErrorCode::OPERATION_TIMEDOUT || response.error.code == ErrorCode::CONNECTION_FAILURE);
 }
 
 TEST(ErrorTests, ChronoConnectTimeoutFailure) {
@@ -55,8 +54,7 @@ TEST(ErrorTests, ChronoConnectTimeoutFailure) {
     Response response = cpr::Get(url, cpr::ConnectTimeout{std::chrono::milliseconds{1}});
     EXPECT_EQ(0, response.status_code);
     // Sometimes a CONNECTION_FAILURE happens before the OPERATION_TIMEDOUT:
-    EXPECT_TRUE(response.error.code == ErrorCode::OPERATION_TIMEDOUT ||
-                response.error.code == ErrorCode::CONNECTION_FAILURE);
+    EXPECT_TRUE(response.error.code == ErrorCode::OPERATION_TIMEDOUT || response.error.code == ErrorCode::CONNECTION_FAILURE);
 }
 
 TEST(ErrorTests, LowSpeedTimeFailure) {

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -632,7 +632,7 @@ void HttpServer::OnRequestDownloadGzip(mg_connection* conn, http_message* msg) {
         if (encoding.find("gzip") == std::string::npos) {
             mg_http_send_error(conn, 405, ("Invalid encoding: " + encoding).c_str());
         } else {
-            if ( !range.empty() ) {
+            if (!range.empty()) {
                 std::string::size_type eq_pos = range.find('=');
                 if (eq_pos == std::string::npos) {
                     mg_http_send_error(conn, 405, ("Invalid range header: " + range).c_str());
@@ -671,7 +671,7 @@ void HttpServer::OnRequestDownloadGzip(mg_connection* conn, http_message* msg) {
                 if (srange >= resp_len) {
                     response.clear();
                     status_code = 206;
-                } else if (erange == -1 || erange >= resp_len ) {
+                } else if (erange == -1 || erange >= resp_len) {
                     response = response.substr(srange);
                     status_code = srange > 0 ? 206 : 200;
                 } else {

--- a/test/httpsServer.cpp
+++ b/test/httpsServer.cpp
@@ -2,10 +2,7 @@
 #include <system_error>
 
 namespace cpr {
-HttpsServer::HttpsServer(std::string&& baseDirPath, std::string&& sslCertFileName,
-                         std::string&& sslKeyFileName)
-        : baseDirPath(std::move(baseDirPath)), sslCertFileName(std::move(sslCertFileName)),
-          sslKeyFileName(std::move(sslKeyFileName)) {}
+HttpsServer::HttpsServer(std::string&& baseDirPath, std::string&& sslCertFileName, std::string&& sslKeyFileName) : baseDirPath(std::move(baseDirPath)), sslCertFileName(std::move(sslCertFileName)), sslKeyFileName(std::move(sslKeyFileName)) {}
 
 std::string HttpsServer::GetBaseUrl() {
     return "https://127.0.0.1:" + std::to_string(GetPort());
@@ -16,8 +13,7 @@ uint16_t HttpsServer::GetPort() {
     return 61937;
 }
 
-mg_connection* HttpsServer::initServer(mg_mgr* mgr,
-                                       MG_CB(mg_event_handler_t event_handler, void* user_data)) {
+mg_connection* HttpsServer::initServer(mg_mgr* mgr, MG_CB(mg_event_handler_t event_handler, void* user_data)) {
     // https://cesanta.com/docs/http/ssl.html
     mg_mgr_init(mgr, this);
 
@@ -42,11 +38,11 @@ void HttpsServer::OnRequest(mg_connection* conn, http_message* msg) {
     }
 }
 
-void HttpsServer::OnRequestNotFound(mg_connection* conn, http_message*  /*msg*/) {
+void HttpsServer::OnRequestNotFound(mg_connection* conn, http_message* /*msg*/) {
     mg_http_send_error(conn, 404, "Not Found");
 }
 
-void HttpsServer::OnRequestHello(mg_connection* conn, http_message*  /*msg*/) {
+void HttpsServer::OnRequestHello(mg_connection* conn, http_message* /*msg*/) {
     std::string response{"Hello world!"};
     std::string headers = "Content-Type: text/html";
     mg_send_head(conn, 200, response.length(), headers.c_str());

--- a/test/httpsServer.hpp
+++ b/test/httpsServer.hpp
@@ -16,8 +16,7 @@ class HttpsServer : public AbstractServer {
     const std::string sslKeyFileName;
 
   public:
-    explicit HttpsServer(std::string&& baseDirPath, std::string&& sslCertFileName,
-                         std::string&& sslKeyFileName);
+    explicit HttpsServer(std::string&& baseDirPath, std::string&& sslCertFileName, std::string&& sslKeyFileName);
     ~HttpsServer() override = default;
 
     std::string GetBaseUrl() override;
@@ -32,8 +31,7 @@ class HttpsServer : public AbstractServer {
     const std::string& getSslKeyFileName() const;
 
   protected:
-    mg_connection* initServer(mg_mgr* mgr,
-                              MG_CB(mg_event_handler_t event_handler, void* user_data)) override;
+    mg_connection* initServer(mg_mgr* mgr, MG_CB(mg_event_handler_t event_handler, void* user_data)) override;
 };
 } // namespace cpr
 

--- a/test/options_tests.cpp
+++ b/test/options_tests.cpp
@@ -16,8 +16,7 @@ TEST(OptionsTests, BaseUrlTest) {
     std::string expected_text{""};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
-    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"},
-              response.header["Access-Control-Allow-Methods"]);
+    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"}, response.header["Access-Control-Allow-Methods"]);
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
@@ -28,8 +27,7 @@ TEST(OptionsTests, SpecificUrlTest) {
     std::string expected_text{""};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
-    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"},
-              response.header["Access-Control-Allow-Methods"]);
+    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"}, response.header["Access-Control-Allow-Methods"]);
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
@@ -45,8 +43,7 @@ TEST(OptionsTests, AsyncBaseUrlTest) {
         std::string expected_text{""};
         EXPECT_EQ(expected_text, response.text);
         EXPECT_EQ(url, response.url);
-        EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"},
-                  response.header["Access-Control-Allow-Methods"]);
+        EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"}, response.header["Access-Control-Allow-Methods"]);
         EXPECT_EQ(200, response.status_code);
         EXPECT_EQ(ErrorCode::OK, response.error.code);
     }
@@ -63,8 +60,7 @@ TEST(OptionsTests, AsyncSpecificUrlTest) {
         std::string expected_text{""};
         EXPECT_EQ(expected_text, response.text);
         EXPECT_EQ(url, response.url);
-        EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"},
-                  response.header["Access-Control-Allow-Methods"]);
+        EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"}, response.header["Access-Control-Allow-Methods"]);
         EXPECT_EQ(200, response.status_code);
         EXPECT_EQ(ErrorCode::OK, response.error.code);
     }

--- a/test/prepare_tests.cpp
+++ b/test/prepare_tests.cpp
@@ -36,8 +36,7 @@ TEST(PrepareTests, OptionsTests) {
     std::string expected_text{""};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
-    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"},
-              response.header["Access-Control-Allow-Methods"]);
+    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"}, response.header["Access-Control-Allow-Methods"]);
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }

--- a/test/raw_body_tests.cpp
+++ b/test/raw_body_tests.cpp
@@ -72,8 +72,7 @@ TEST(BodyPostTests, UrlEncodedManyPostTest) {
 
 TEST(BodyPostTests, CustomHeaderNumberPostTest) {
     Url url{server->GetBaseUrl() + "/json_post.html"};
-    Response response =
-            cpr::Post(url, Body{"{\"x\":5}"}, Header{{"Content-Type", "application/json"}});
+    Response response = cpr::Post(url, Body{"{\"x\":5}"}, Header{{"Content-Type", "application/json"}});
     std::string expected_text{"{\"x\":5}"};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
@@ -84,8 +83,7 @@ TEST(BodyPostTests, CustomHeaderNumberPostTest) {
 
 TEST(BodyPostTests, CustomHeaderTextPostTest) {
     Url url{server->GetBaseUrl() + "/json_post.html"};
-    Response response = cpr::Post(url, Body{"{\"x\":\"hello world!!~\"}"},
-                                  Header{{"Content-Type", "application/json"}});
+    Response response = cpr::Post(url, Body{"{\"x\":\"hello world!!~\"}"}, Header{{"Content-Type", "application/json"}});
     std::string expected_text{"{\"x\":\"hello world!!~\"}"};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);

--- a/test/ssl_tests.cpp
+++ b/test/ssl_tests.cpp
@@ -20,11 +20,7 @@ TEST(SslTests, HelloWorldTestSimpel) {
 
     Url url{server->GetBaseUrl() + "/hello.html"};
     std::string baseDirPath = server->getBaseDirPath();
-    SslOptions sslOpts =
-            Ssl(ssl::CaPath{baseDirPath + "ca.cer"}, ssl::CertFile{baseDirPath + "client.cer"},
-                ssl::KeyFile{baseDirPath + "client.key"}, ssl::VerifyPeer{false},
-                ssl::PinnedPublicKey{baseDirPath + "server.pubkey"},
-                ssl::VerifyHost{false}, ssl::VerifyStatus{false});
+    SslOptions sslOpts = Ssl(ssl::CaPath{baseDirPath + "ca.cer"}, ssl::CertFile{baseDirPath + "client.cer"}, ssl::KeyFile{baseDirPath + "client.key"}, ssl::VerifyPeer{false}, ssl::PinnedPublicKey{baseDirPath + "server.pubkey"}, ssl::VerifyHost{false}, ssl::VerifyStatus{false});
     Response response = cpr::Get(url, sslOpts, Timeout{5000}, Verbose{});
     std::string expected_text = "Hello world!";
     EXPECT_EQ(expected_text, response.text);
@@ -39,11 +35,7 @@ TEST(SslTests, HelloWorldTestFull) {
 
     Url url{server->GetBaseUrl() + "/hello.html"};
     std::string baseDirPath = server->getBaseDirPath();
-    SslOptions sslOpts = Ssl(
-            ssl::TLSv1{}, ssl::ALPN{false}, ssl::NPN{false}, ssl::CaPath{baseDirPath + "ca.cer"},
-            ssl::CertFile{baseDirPath + "client.cer"}, ssl::KeyFile{baseDirPath + "client.key"},
-            ssl::PinnedPublicKey{baseDirPath + "server.pubkey"},
-            ssl::VerifyPeer{false}, ssl::VerifyHost{false}, ssl::VerifyStatus{false});
+    SslOptions sslOpts = Ssl(ssl::TLSv1{}, ssl::ALPN{false}, ssl::NPN{false}, ssl::CaPath{baseDirPath + "ca.cer"}, ssl::CertFile{baseDirPath + "client.cer"}, ssl::KeyFile{baseDirPath + "client.key"}, ssl::PinnedPublicKey{baseDirPath + "server.pubkey"}, ssl::VerifyPeer{false}, ssl::VerifyHost{false}, ssl::VerifyStatus{false});
     Response response = cpr::Get(url, sslOpts, Timeout{5000}, Verbose{});
     std::string expected_text = "Hello world!";
     EXPECT_EQ(expected_text, response.text);
@@ -58,10 +50,7 @@ TEST(SslTests, GetCertInfo) {
 
     Url url{server->GetBaseUrl() + "/hello.html"};
     std::string baseDirPath = server->getBaseDirPath();
-    SslOptions sslOpts =
-            Ssl(ssl::CaPath{baseDirPath + "ca.cer"}, ssl::CertFile{baseDirPath + "client.cer"},
-                ssl::KeyFile{baseDirPath + "client.key"}, ssl::VerifyPeer{false},
-                ssl::VerifyHost{false}, ssl::VerifyStatus{false});
+    SslOptions sslOpts = Ssl(ssl::CaPath{baseDirPath + "ca.cer"}, ssl::CertFile{baseDirPath + "client.cer"}, ssl::KeyFile{baseDirPath + "client.key"}, ssl::VerifyPeer{false}, ssl::VerifyHost{false}, ssl::VerifyStatus{false});
     Response response = cpr::Get(url, sslOpts, Timeout{5000}, Verbose{});
     std::string expected_text = "Hello world!";
     EXPECT_EQ(expected_text, response.text);
@@ -99,8 +88,7 @@ int main(int argc, char** argv) {
     std::string baseDirPath = getBasePath(argv[0]);
     std::string serverCertPath = baseDirPath + "server.cer";
     std::string serverKeyPath = baseDirPath + "server.key";
-    server = new HttpsServer(std::move(baseDirPath), std::move(serverCertPath),
-                             std::move(serverKeyPath));
+    server = new HttpsServer(std::move(baseDirPath), std::move(serverCertPath), std::move(serverKeyPath));
     ::testing::AddGlobalTestEnvironment(server);
 
     return RUN_ALL_TESTS();

--- a/test/structures_tests.cpp
+++ b/test/structures_tests.cpp
@@ -3,15 +3,15 @@
 
 #include <string>
 
-#include <cpr/payload.h>
 #include <cpr/parameters.h>
+#include <cpr/payload.h>
 
 using namespace cpr;
 
 TEST(PayloadTests, UseStringVariableTest) {
     std::string value1 = "hello";
     std::string key2 = "key2";
-    Payload payload {{"key1", value1}, {key2, "world"}};
+    Payload payload{{"key1", value1}, {key2, "world"}};
 
     std::string expected = "key1=hello&key2=world";
     EXPECT_EQ(payload.GetContent(CurlHolder()), expected);
@@ -32,7 +32,7 @@ TEST(PayloadTests, DisableEncodingTest) {
 TEST(ParametersTests, UseStringVariableTest) {
     std::string value1 = "hello";
     std::string key2 = "key2";
-    Parameters parameters {{"key1", value1}, {key2, "world"}};
+    Parameters parameters{{"key1", value1}, {key2, "world"}};
 
     std::string expected = "key1=hello&key2=world";
     EXPECT_EQ(parameters.GetContent(CurlHolder()), expected);


### PR DESCRIPTION
Adds a `clang-format` CI run and extracts out `clang-tidy` and `cppcheck` to their own files.

Also I run `clang-format` for all files in this repo.