### PR TITLE
Added function to get the full request URL

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -81,6 +81,7 @@ class Session::Impl {
     Response Put();
 
     std::shared_ptr<CurlHolder> GetCurlHolder();
+    std::string GetFullRequestUrl();
 
     void PrepareDelete();
     void PrepareGet();
@@ -708,6 +709,11 @@ std::shared_ptr<CurlHolder> Session::Impl::GetCurlHolder() {
     return curl_;
 }
 
+std::string Session::Impl::GetFullRequestUrl() {
+    const std::string parametersContent = parameters_.GetContent(*curl_);
+    return url_.str() + (parametersContent.empty() ? "" : "?") + parametersContent;
+}
+
 Response Session::Impl::makeDownloadRequest() {
     assert(curl_->handle);
 
@@ -928,6 +934,7 @@ Response Session::Post() { return pimpl_->Post(); }
 Response Session::Put() { return pimpl_->Put(); }
 
 std::shared_ptr<CurlHolder> Session::GetCurlHolder() { return pimpl_->GetCurlHolder(); }
+std::string Session::GetFullRequestUrl() { return pimpl_->GetFullRequestUrl(); }
 
 void Session::PrepareDelete() { return pimpl_->PrepareDelete(); }
 void Session::PrepareGet() { return pimpl_->PrepareGet(); }

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -146,6 +146,7 @@ class Session {
     Response Put();
 
     std::shared_ptr<CurlHolder> GetCurlHolder();
+    std::string GetFullRequestUrl();
 
     void PrepareDelete();
     void PrepareGet();

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -349,6 +349,34 @@ TEST(ParameterTests, ParameterMultipleTest) {
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 
+TEST(FullRequestUrlTest, GetFullRequestUrlNoParametersTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    Session session;
+    session.SetUrl(url);
+    std::string expected_text{server->GetBaseUrl() + "/hello.html"};
+    EXPECT_EQ(expected_text, session.GetFullRequestUrl());
+}
+
+TEST(FullRequestUrlTest, GetFullRequestUrlOneParameterTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    Session session;
+    session.SetUrl(url);
+    Parameters parameters{{"hello", "world"}};
+    session.SetParameters(parameters);
+    std::string expected_text{server->GetBaseUrl() + "/hello.html" + "?hello=world"};
+    EXPECT_EQ(expected_text, session.GetFullRequestUrl());
+}
+
+TEST(FullRequestUrlTest, GetFullRequestUrlMultipleParametersTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    Session session;
+    session.SetUrl(url);
+    Parameters parameters{{"hello", "world"}, {"key", "value"}};
+    session.SetParameters(parameters);
+    std::string expected_text{server->GetBaseUrl() + "/hello.html" + "?hello=world&key=value"};
+    EXPECT_EQ(expected_text, session.GetFullRequestUrl());
+}
+
 TEST(TimeoutTests, SetTimeoutTest) {
     Url url{server->GetBaseUrl() + "/hello.html"};
     Session session;


### PR DESCRIPTION
Closes #270 

Added a function Session::GetFullRequestUrl() that allows the user to get the full request URL before actually making a request. This could be useful for unit testing or debugging.