### PR TITLE
Improved range requests and added support for multiple ranges

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -66,6 +66,7 @@ class Session::Impl {
     void SetInterface(const Interface& iface);
     void SetHttpVersion(const HttpVersion& version);
     void SetRange(const Range& range);
+    void SetMultiRange(const MultiRange& multi_range);
     void SetReserveSize(const ReserveSize& reserve_size);
 
     cpr_off_t GetDownloadFileLength();
@@ -560,6 +561,11 @@ void Session::Impl::SetRange(const Range& range) {
     curl_easy_setopt(curl_->handle, CURLOPT_RANGE, range_str.c_str());
 }
 
+void Session::Impl::SetMultiRange(const MultiRange& multi_range) {
+    std::string multi_range_str = multi_range.str();
+    curl_easy_setopt(curl_->handle, CURLOPT_RANGE, multi_range_str.c_str());
+}
+
 void Session::Impl::SetReserveSize(const ReserveSize& reserve_size) {
     ResponseStringReserve(reserve_size.size);
 }
@@ -875,6 +881,7 @@ void Session::SetVerbose(const Verbose& verbose) { pimpl_->SetVerbose(verbose); 
 void Session::SetInterface(const Interface& iface) { pimpl_->SetInterface(iface); }
 void Session::SetHttpVersion(const HttpVersion& version) { pimpl_->SetHttpVersion(version); }
 void Session::SetRange(const Range& range) { pimpl_->SetRange(range); }
+void Session::SetMultiRange(const MultiRange& multi_range) { pimpl_->SetMultiRange(multi_range); }
 void Session::SetReserveSize(const ReserveSize& reserve_size) { pimpl_->SetReserveSize(reserve_size); }
 void Session::SetOption(const ReadCallback& read) { pimpl_->SetReadCallback(read); }
 void Session::SetOption(const HeaderCallback& header) { pimpl_->SetHeaderCallback(header); }
@@ -915,6 +922,7 @@ void Session::SetOption(const SslOptions& options) { pimpl_->SetSslOptions(optio
 void Session::SetOption(const Interface& iface) { pimpl_->SetInterface(iface); }
 void Session::SetOption(const HttpVersion& version) { pimpl_->SetHttpVersion(version); }
 void Session::SetOption(const Range& range) { pimpl_->SetRange(range); }
+void Session::SetOption(const MultiRange& multi_range) { pimpl_->SetMultiRange(multi_range); }
 void Session::SetOption(const ReserveSize& reserve_size) { pimpl_->SetReserveSize(reserve_size.size); }
 
 cpr_off_t Session::GetDownloadFileLength() { return pimpl_->GetDownloadFileLength(); }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -556,9 +556,7 @@ void Session::Impl::SetSslOptions(const SslOptions& options) {
 }
 
 void Session::Impl::SetRange(const Range& range) {
-    curl_off_t resume_from = range.resume_from;
-    curl_off_t finish_at = range.finish_at;
-    std::string range_str = std::to_string(resume_from) + "-" + std::to_string(finish_at);
+    std::string range_str = range.str();
     curl_easy_setopt(curl_->handle, CURLOPT_RANGE, range_str.c_str());
 }
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -560,8 +560,6 @@ void Session::Impl::SetRange(const Range& range) {
     curl_off_t finish_at = range.finish_at;
     std::string range_str = std::to_string(resume_from) + "-" + std::to_string(finish_at);
     curl_easy_setopt(curl_->handle, CURLOPT_RANGE, range_str.c_str());
-    curl_easy_setopt(curl_->handle, CURLOPT_RESUME_FROM_LARGE, resume_from);
-    curl_easy_setopt(curl_->handle, CURLOPT_INFILESIZE_LARGE, finish_at);
 }
 
 void Session::Impl::SetReserveSize(const ReserveSize& reserve_size) {

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -26,7 +26,7 @@ class MultiRange {
     const std::string str() const {
         std::string multi_range_string{};
         for (Range range : ranges) {
-            multi_range_string += ((multi_range_string.empty()) ? "" : ",") + range.str();
+            multi_range_string += ((multi_range_string.empty()) ? "" : ", ") + range.str();
         }
         return multi_range_string;
     }

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -11,6 +11,10 @@ class Range {
 
     std::int64_t resume_from = 0;
     std::int64_t finish_at = 0;
+
+    const std::string str() const {
+        return std::to_string(resume_from) + "-" + std::to_string(finish_at);
+    }
 };
 
 } // namespace cpr

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -13,8 +13,8 @@ class Range {
     std::int64_t finish_at = 0;
 
     const std::string str() const {
-        std::string from_str = (resume_from < 0) ? "" : std::to_string(resume_from);
-        std::string to_str = (finish_at < 0) ? "" : std::to_string(finish_at);
+        std::string from_str = (resume_from < (std::int64_t) 0) ? "" : std::to_string(resume_from);
+        std::string to_str = (finish_at < (std::int64_t) 0) ? "" : std::to_string(finish_at);
         return from_str + "-" + to_str;
     }
 };

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -13,8 +13,8 @@ class Range {
     std::int64_t finish_at = 0;
 
     const std::string str() const {
-        std::string from_str = (resume_from == -1) ? "" : std::to_string(resume_from);
-        std::string to_str = (finish_at == -1) ? "" : std::to_string(finish_at);
+        std::string from_str = (resume_from < 0) ? "" : std::to_string(resume_from);
+        std::string to_str = (finish_at < 0) ? "" : std::to_string(finish_at);
         return from_str + "-" + to_str;
     }
 };

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -13,7 +13,9 @@ class Range {
     std::int64_t finish_at = 0;
 
     const std::string str() const {
-        return std::to_string(resume_from) + "-" + std::to_string(finish_at);
+        std::string from_str = (resume_from == -1) ? "" : std::to_string(resume_from);
+        std::string to_str = (finish_at == -1) ? "" : std::to_string(finish_at);
+        return from_str + "-" + to_str;
     }
 };
 

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -17,6 +17,22 @@ class Range {
     }
 };
 
+class MultiRange {
+  public:
+    MultiRange(std::initializer_list<Range> rs) : ranges{rs} {}
+
+    const std::string str() const {
+        std::string multi_range_string{};
+        for (Range range : ranges) {
+            multi_range_string += ((multi_range_string.empty()) ? "" : ",") + range.str();
+        }
+        return multi_range_string;
+    }
+
+  private:
+    std::vector<Range> ranges;
+}; // namespace cpr
+
 } // namespace cpr
 
 #endif

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -79,6 +79,7 @@ class Session {
     void SetInterface(const Interface& iface);
     void SetHttpVersion(const HttpVersion& version);
     void SetRange(const Range& range);
+    void SetMultiRange(const MultiRange& multi_range);
     void SetReserveSize(const ReserveSize& reserve_size);
 
     // Used in templated functions
@@ -121,6 +122,7 @@ class Session {
     void SetOption(const Interface& iface);
     void SetOption(const HttpVersion& version);
     void SetOption(const Range& range);
+    void SetOption(const MultiRange& multi_range);
     void SetOption(const ReserveSize& reserve_size);
 
     cpr_off_t GetDownloadFileLength();

--- a/test/download_tests.cpp
+++ b/test/download_tests.cpp
@@ -68,6 +68,21 @@ TEST(DownloadTests, RangeTestUpperLimit) {
     EXPECT_EQ(download_size, response.downloaded_bytes);
 }
 
+TEST(DownloadTests, RangeTestLowerAndUpperLimit) {
+    const int64_t download_size = 2;
+    const int64_t start_from = 2;
+    const int64_t finish_at = start_from + download_size - 1;
+    cpr::Url url{server->GetBaseUrl() + "/download_gzip.html"};
+    cpr::Session session;
+    session.SetUrl(url);
+    session.SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+    session.SetRange(cpr::Range{start_from, finish_at});
+    cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
+    EXPECT_EQ(206, response.status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
+    EXPECT_EQ(download_size, response.downloaded_bytes);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(server);

--- a/test/download_tests.cpp
+++ b/test/download_tests.cpp
@@ -83,6 +83,34 @@ TEST(DownloadTests, RangeTestLowerAndUpperLimit) {
     EXPECT_EQ(download_size, response.downloaded_bytes);
 }
 
+TEST(DownloadTests, RangeTestMultipleRangesSet) {
+    const int64_t num_parts = 2;
+    const int64_t download_size = num_parts * (26 /*content range*/ + 4 /*\n*/) + ((num_parts + 1) * 15 /*boundary*/) + 2 /*--*/ + 6 /*data*/;
+    cpr::Url url{server->GetBaseUrl() + "/download_gzip.html"};
+    cpr::Session session;
+    session.SetUrl(url);
+    session.SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+    session.SetMultiRange(cpr::MultiRange{cpr::Range{0, 3}, cpr::Range{5, 6}});
+    cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
+    EXPECT_EQ(206, response.status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
+    EXPECT_EQ(download_size, response.downloaded_bytes);
+}
+
+TEST(DownloadTests, RangeTestMultipleRangesOption) {
+    const int64_t num_parts = 3;
+    const int64_t download_size = num_parts * (26 /*content range*/ + 4 /*\n*/) + ((num_parts + 1) * 15 /*boundary*/) + 2 /*--*/ + 7 /*data*/;
+    cpr::Url url{server->GetBaseUrl() + "/download_gzip.html"};
+    cpr::Session session;
+    session.SetUrl(url);
+    session.SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+    session.SetOption(cpr::MultiRange{cpr::Range{0, 2}, cpr::Range{4, 5}, cpr::Range{7, 8}});
+    cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
+    EXPECT_EQ(206, response.status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
+    EXPECT_EQ(download_size, response.downloaded_bytes);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(server);

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -642,11 +642,19 @@ void HttpServer::OnRequestDownloadGzip(mg_connection* conn, http_message* msg) {
 
             int64_t current_start_index = eq_pos + 1;
             int64_t current_end_index;
+            std::string::size_type range_len = range.length();
+            std::string::size_type com_pos;
             std::string::size_type sep_pos;
             bool more_ranges_exists;
 
             do {
-                current_end_index = std::min(range.find(',', current_start_index) - 1, range.length() - 1);
+                com_pos = range.find(',', current_start_index);
+                if (com_pos < range_len) {
+                    current_end_index = com_pos - 1;
+                } else {
+                    current_end_index = range_len - 1;
+                }
+
                 std::pair<int64_t, int64_t> current_range{0, -1};
 
                 sep_pos = range.find('-', current_start_index);

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -615,8 +615,8 @@ void HttpServer::OnRequestDownloadGzip(mg_connection* conn, http_message* msg) {
     } else {
         std::string encoding;
         std::string range;
-        int64_t srange = 0;
-        int64_t erange = -1;
+        std::vector<std::pair<int64_t, int64_t>> ranges;
+
         for (size_t i = 0; i < sizeof(msg->header_names) / sizeof(mg_str); i++) {
             if (!msg->header_names[i].p) {
                 continue;
@@ -631,67 +631,125 @@ void HttpServer::OnRequestDownloadGzip(mg_connection* conn, http_message* msg) {
         }
         if (encoding.find("gzip") == std::string::npos) {
             mg_http_send_error(conn, 405, ("Invalid encoding: " + encoding).c_str());
-        } else {
-            if (!range.empty()) {
-                std::string::size_type eq_pos = range.find('=');
-                if (eq_pos == std::string::npos) {
-                    mg_http_send_error(conn, 405, ("Invalid range header: " + range).c_str());
-                    return;
-                }
-                std::string::size_type sep_pos = range.find('-', eq_pos + 1);
+            return;
+        }
+        if (!range.empty()) {
+            std::string::size_type eq_pos = range.find('=');
+            if (eq_pos == std::string::npos) {
+                mg_http_send_error(conn, 405, ("Invalid range header: " + range).c_str());
+                return;
+            }
+
+            int64_t current_start_index = eq_pos + 1;
+            int64_t current_end_index;
+            std::string::size_type sep_pos;
+            bool more_ranges_exists{true};
+
+            while (more_ranges_exists) {
+                current_end_index = std::min(range.find(',', current_start_index) - 1, range.length() - 1);
+                int64_t current_srange = 0;
+                int64_t current_erange = -1;
+
+                sep_pos = range.find('-', current_start_index);
                 if (sep_pos == std::string::npos) {
                     mg_http_send_error(conn, 405, ("Invalid range format " + range).c_str());
                     return;
                 }
-                if (sep_pos != std::string::npos) {
-                    if (sep_pos == eq_pos + 1) {
-                        mg_http_send_error(conn, 405, ("Suffix ranage not supported: " + range).c_str());
+                if (sep_pos == eq_pos + 1) {
+                    mg_http_send_error(conn, 405, ("Suffix ranage not supported: " + range).c_str());
+                    return;
+                }
+
+                current_srange = std::strtoll(range.substr(current_start_index, sep_pos - 1).c_str(), nullptr, 10);
+                if (current_srange == LLONG_MAX || current_srange == LLONG_MIN) {
+                    mg_http_send_error(conn, 405, ("Start range is invalid number: " + range).c_str());
+                    return;
+                }
+
+                std::string er_str = range.substr(sep_pos + 1, current_end_index);
+                if (!er_str.empty()) {
+                    current_erange = std::strtoll(er_str.c_str(), nullptr, 10);
+                    if (current_erange == 0 || current_erange == LLONG_MAX || current_erange == LLONG_MIN) {
+                        mg_http_send_error(conn, 405, ("End range is invalid number: " + range).c_str());
                         return;
                     }
-                    srange = std::strtoll(range.substr(eq_pos + 1, sep_pos - eq_pos - 1).c_str(), nullptr, 10);
-                    if (srange == LLONG_MAX || srange == LLONG_MIN) {
-                        mg_http_send_error(conn, 405, ("Start range is invalid number: " + range).c_str());
-                        return;
-                    }
-                    std::string::size_type coma_pos = range.find(',', sep_pos + 1);
-                    std::string er_str = range.substr(sep_pos + 1, coma_pos);
-                    if (!er_str.empty()) {
-                        erange = std::strtoll(er_str.c_str(), nullptr, 10);
-                        if (erange == 0 || erange == LLONG_MAX || erange == LLONG_MIN) {
-                            mg_http_send_error(conn, 405, ("End range is invalid number: " + range).c_str());
-                            return;
-                        }
+                }
+
+                ranges.push_back(std::pair<int64_t, int64_t>{current_srange, current_erange});
+
+                if (current_end_index >= (int64_t)(range.length() - 1)) {
+                    more_ranges_exists = false;
+                } else {
+                    current_start_index = current_end_index + 2;
+                }
+            }
+        }
+
+        std::string response = "Download!";
+        int status_code = 200;
+        std::string headers;
+
+        if (!ranges.empty()) {
+            std::vector<std::string> responses;
+            std::int64_t resp_len = response.length();
+            int64_t srange;
+            int64_t erange;
+
+            for (std::pair<int64_t, int64_t> range : ranges) {
+                srange = range.first;
+                erange = range.second;
+
+                if (srange >= 0) {
+                    if (srange >= resp_len) {
+                        responses.push_back("");
+                    } else if (erange == -1 || erange >= resp_len) {
+                        responses.push_back(response.substr(srange));
+                    } else {
+                        responses.push_back(response.substr(srange, erange - srange + 1));
                     }
                 }
             }
-            std::string response = "Download!";
-            int status_code = 200;
-            if (srange >= 0) {
-                int64_t resp_len = response.length();
-                if (srange >= resp_len) {
-                    response.clear();
-                    status_code = 206;
-                } else if (erange == -1 || erange >= resp_len) {
-                    response = response.substr(srange);
+
+            if (responses.size() > 1) {
+                std::string boundary = "3d6b6a416f9b5";
+                status_code = 206;
+                response.clear();
+
+                for (size_t i{0}; i < responses.size(); ++i) {
+                    response += "--" + boundary + "\n";
+                    response += "Content-Range: bytes " + std::to_string(ranges.at(i).first) + "-";
+                    if (ranges.at(i).second > 0) {
+                        response += std::to_string(ranges.at(i).second);
+                    } else {
+                        response += std::to_string(responses.at(i).length());
+                    }
+                    response += "/" + std::to_string(responses.at(i).length()) + "\n\n";
+                    response += responses.at(i) + "\n";
+                }
+
+                response += "--" + boundary + "--";
+            } else {
+                if (ranges.at(0).second == -1 || ranges.at(0).second >= resp_len) {
                     status_code = srange > 0 ? 206 : 200;
                 } else {
-                    response = response.substr(srange, erange - srange + 1);
                     status_code = 206;
                 }
-            }
-            std::string headers;
-            if (status_code == 206) {
-                headers = "Content-Range: bytes " + std::to_string(srange) + "-";
-                if (erange > 0) {
-                    headers += std::to_string(erange);
-                } else {
-                    headers += std::to_string(response.length());
+                response = responses.at(0);
+
+                if (status_code == 206) {
+                    headers = "Content-Range: bytes " + std::to_string(ranges.at(0).first) + "-";
+                    if (ranges.at(0).second > 0) {
+                        headers += std::to_string(ranges.at(0).second);
+                    } else {
+                        headers += std::to_string(response.length());
+                    }
+                    headers += "/" + std::to_string(response.length());
                 }
-                headers += "/" + std::to_string(response.length());
             }
-            mg_send_head(conn, status_code, static_cast<int>(response.length()), headers.c_str());
-            mg_send(conn, response.c_str(), static_cast<int>(response.length()));
         }
+
+        mg_send_head(conn, status_code, static_cast<int>(response.length()), headers.c_str());
+        mg_send(conn, response.c_str(), static_cast<int>(response.length()));
     }
 }
 

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -679,9 +679,9 @@ void HttpServer::OnRequestDownloadGzip(mg_connection* conn, http_message* msg) {
                 if (current_end_index >= (int64_t)(range.length() - 1)) {
                     more_ranges_exists = false;
                 } else {
-                    // Multiple ranges are separated by ','
+                    // Multiple ranges are separated by ', '
                     more_ranges_exists = true;
-                    current_start_index = current_end_index + 2;
+                    current_start_index = current_end_index + 3;
                 }
             } while (more_ranges_exists);
         }


### PR DESCRIPTION
Closes #75 

Improves range requests introduced in #701 and added support for multiple ranges in a single request ([multipart ranges](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#multipart_ranges)).