### PR TITLE
Add method SetAcceptEncoding for customized Accept-Encoding header (#683)

### DIFF
--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 add_library(cpr
+    accept_encoding.cpp
     async.cpp
     auth.cpp
     bearer.cpp

--- a/cpr/accept_encoding.cpp
+++ b/cpr/accept_encoding.cpp
@@ -1,0 +1,25 @@
+#include "cpr/accept_encoding.h"
+
+#include <algorithm>
+#include <iterator>
+#include <numeric>
+
+namespace cpr {
+
+AcceptEncoding::AcceptEncoding(const std::initializer_list<AcceptEncodingMethods>& methods) {
+    methods_.clear();
+    std::transform(methods.begin(), methods.end(), std::back_inserter(methods_), [&](cpr::AcceptEncodingMethods method) { return cpr::AcceptEncodingMethodsStringMap.at(method); });
+}
+
+AcceptEncoding::AcceptEncoding(const std::initializer_list<std::string>& string_methods) : methods_{string_methods} {}
+
+bool AcceptEncoding::empty() const noexcept {
+    return methods_.empty();
+}
+
+const std::string AcceptEncoding::getString() const {
+    std::string methodsString = std::accumulate(std::next(methods_.begin()), methods_.end(), methods_[0], [](std::string a, std::string b) { return std::move(a) + ", " + std::move(b); });
+    return methodsString;
+}
+
+} // namespace cpr

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,6 +7,7 @@ target_include_directories(cpr PUBLIC
 
 target_sources(cpr PRIVATE
      # Header files (useful in IDEs)
+    cpr/accept_encoding.h
     cpr/api.h
     cpr/async.h
     cpr/auth.h

--- a/include/cpr/accept_encoding.h
+++ b/include/cpr/accept_encoding.h
@@ -1,0 +1,36 @@
+#ifndef CPR_ACCEPT_ENCODING_H
+#define CPR_ACCEPT_ENCODING_H
+
+#include <curl/curlver.h>
+#include <initializer_list>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace cpr {
+
+enum class AcceptEncodingMethods {
+    identity,
+    deflate,
+    zlib,
+    gzip,
+};
+
+static const std::map<AcceptEncodingMethods, std::string> AcceptEncodingMethodsStringMap{{AcceptEncodingMethods::identity, "identity"}, {AcceptEncodingMethods::deflate, "deflate"}, {AcceptEncodingMethods::zlib, "zlib"}, {AcceptEncodingMethods::gzip, "gzip"}};
+
+class AcceptEncoding {
+  public:
+    AcceptEncoding() = default;
+    AcceptEncoding(const std::initializer_list<AcceptEncodingMethods>& methods);
+    AcceptEncoding(const std::initializer_list<std::string>& methods);
+
+    bool empty() const noexcept;
+    const std::string getString() const;
+
+  private:
+    std::vector<std::string> methods_;
+};
+
+} // namespace cpr
+
+#endif

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -13,6 +13,7 @@
 #include "cpr/cookies.h"
 #include "cpr/cprtypes.h"
 #include "cpr/curlholder.h"
+#include "cpr/accept_encoding.h"
 #include "cpr/http_version.h"
 #include "cpr/interface.h"
 #include "cpr/limit_rate.h"
@@ -87,6 +88,8 @@ class Session {
     void SetRange(const Range& range);
     void SetMultiRange(const MultiRange& multi_range);
     void SetReserveSize(const ReserveSize& reserve_size);
+    void SetAcceptEncoding(const AcceptEncoding& accept_encoding);
+    void SetAcceptEncoding(AcceptEncoding&& accept_encoding);
 
     // Used in templated functions
     void SetOption(const Url& url);
@@ -132,6 +135,8 @@ class Session {
     void SetOption(const Range& range);
     void SetOption(const MultiRange& multi_range);
     void SetOption(const ReserveSize& reserve_size);
+    void SetOption(const AcceptEncoding& accept_encoding);
+    void SetOption(AcceptEncoding&& accept_encoding);
 
     cpr_off_t GetDownloadFileLength();
     /**

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -756,6 +756,22 @@ void HttpServer::OnRequestDownloadGzip(mg_connection* conn, http_message* msg) {
     }
 }
 
+void HttpServer::OnRequestCheckAcceptEncoding(mg_connection* conn, http_message* msg) {
+    std::string response;
+    for (size_t i = 0; i < sizeof(msg->header_names) / sizeof(mg_str); i++) {
+        if (!msg->header_names[i].p) {
+            continue;
+        }
+        std::string name = std::string(msg->header_names[i].p, msg->header_names[i].len);
+        if (std::string{"Accept-Encoding"} == name) {
+            response = std::string(msg->header_values[i].p, msg->header_values[i].len);
+        }
+    }
+    std::string headers = "Content-Type: text/html";
+    mg_send_head(conn, 200, response.length(), headers.c_str());
+    mg_send(conn, response.c_str(), response.length());
+}
+
 void HttpServer::OnRequest(mg_connection* conn, http_message* msg) {
     std::string uri = std::string(msg->uri.p, msg->uri.len);
     if (uri == "/") {
@@ -822,6 +838,8 @@ void HttpServer::OnRequest(mg_connection* conn, http_message* msg) {
         OnRequestDownloadGzip(conn, msg);
     } else if (uri == "/local_port.html") {
         OnRequestLocalPort(conn, msg);
+    } else if (uri == "/check_accept_encoding.html") {
+        OnRequestCheckAcceptEncoding(conn, msg);
     } else {
         OnRequestNotFound(conn, msg);
     }

--- a/test/httpServer.hpp
+++ b/test/httpServer.hpp
@@ -52,6 +52,7 @@ class HttpServer : public AbstractServer {
     static void OnRequestPatchNotAllowed(mg_connection* conn, http_message* msg);
     static void OnRequestDownloadGzip(mg_connection* conn, http_message* msg);
     static void OnRequestLocalPort(mg_connection* conn, http_message* msg);
+    static void OnRequestCheckAcceptEncoding(mg_connection* conn, http_message* msg);
 
   protected:
     mg_connection* initServer(mg_mgr* mgr, MG_CB(mg_event_handler_t event_handler, void* user_data)) override;

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -1004,6 +1004,64 @@ TEST(BasicTests, ReserveResponseString) {
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 
+TEST(BasicTests, AcceptEncodingTestWithMethodsStringMap) {
+    Url url{server->GetBaseUrl() + "/check_accept_encoding.html"};
+    Session session;
+    session.SetUrl(url);
+    session.SetAcceptEncoding({{AcceptEncodingMethods::deflate, AcceptEncodingMethods::gzip, AcceptEncodingMethods::zlib}});
+    Response response = session.Get();
+    std::string expected_text{"deflate, gzip, zlib"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(BasicTests, AcceptEncodingTestWithMethodsStringMapLValue) {
+    Url url{server->GetBaseUrl() + "/check_accept_encoding.html"};
+    Session session;
+    session.SetUrl(url);
+    AcceptEncoding accept_encoding{{AcceptEncodingMethods::deflate, AcceptEncodingMethods::gzip, AcceptEncodingMethods::zlib}};
+    session.SetAcceptEncoding(accept_encoding);
+    Response response = session.Get();
+    std::string expected_text{"deflate, gzip, zlib"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(BasicTests, AcceptEncodingTestWithCostomizedString) {
+    Url url{server->GetBaseUrl() + "/check_accept_encoding.html"};
+    Session session;
+    session.SetUrl(url);
+    session.SetAcceptEncoding({{"deflate", "gzip", "zlib"}});
+    Response response = session.Get();
+    std::string expected_text{"deflate, gzip, zlib"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(BasicTests, AcceptEncodingTestWithCostomizedStringLValue) {
+    Url url{server->GetBaseUrl() + "/check_accept_encoding.html"};
+    Session session;
+    session.SetUrl(url);
+    AcceptEncoding accept_encoding{{"deflate", "gzip", "zlib"}};
+    session.SetAcceptEncoding(accept_encoding);
+    Response response = session.Get();
+    std::string expected_text{"deflate, gzip, zlib"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(server);


### PR DESCRIPTION
1. New class for managing header Accept-Encoding refers to proxies structure.cpp
2. New method to set header Accept-Encoding
3. New unit test to verify header Accept-Encoding