### PR TITLE
Add support for uploading arbitrary file parts with CURLOPT_RESUME_FROM

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -611,7 +611,8 @@ void Session::Impl::SetUploadRange(const UploadRange& upload_range) {
     curl_off_t filesize = upload_range.getFilesize();
 
     // Create upload range header
-    std::array<char, 256> range_header;
+    constexpr int max_header_char_count{256};
+    std::array<char, max_header_char_count> range_header{};
     sprintf(range_header.data(),
             "Content-Range: bytes %" CURL_FORMAT_CURL_OFF_T
             "-"

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -1005,6 +1005,7 @@ void Session::SetOption(const MultiRange& multi_range) { pimpl_->SetMultiRange(m
 void Session::SetOption(const ReserveSize& reserve_size) { pimpl_->SetReserveSize(reserve_size.size); }
 void Session::SetOption(const AcceptEncoding& accept_encoding) { pimpl_->SetAcceptEncoding(accept_encoding); }
 void Session::SetOption(AcceptEncoding&& accept_encoding) { pimpl_->SetAcceptEncoding(std::move(accept_encoding)); }
+void Session::SetOption(const UploadRange& upload_range) { pimpl_->SetUploadRange(upload_range); }
 
 cpr_off_t Session::GetDownloadFileLength() { return pimpl_->GetDownloadFileLength(); }
 void Session::ResponseStringReserve(size_t size) { pimpl_->ResponseStringReserve(size); }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -78,6 +78,7 @@ class Session::Impl {
     void SetReserveSize(const ReserveSize& reserve_size);
     void SetAcceptEncoding(AcceptEncoding&& accept_encoding);
     void SetAcceptEncoding(const AcceptEncoding& accept_encoding);
+    void SetUploadRange(const UploadRange& upload_range);
 
     cpr_off_t GetDownloadFileLength();
     void ResponseStringReserve(size_t size);
@@ -599,6 +600,13 @@ void Session::Impl::SetMultiRange(const MultiRange& multi_range) {
     curl_easy_setopt(curl_->handle, CURLOPT_RANGE, multi_range_str.c_str());
 }
 
+void Session::Impl::SetUploadRange(const UploadRange& upload_range) {
+    curl_off_t resume_from = upload_range.getResumeFrom();
+    curl_off_t filesize = upload_range.getFilesize();
+    curl_easy_setopt(curl_->handle, CURLOPT_RESUME_FROM_LARGE, resume_from);
+    curl_easy_setopt(curl_->handle, CURLOPT_INFILESIZE_LARGE, filesize);
+}
+
 void Session::Impl::SetReserveSize(const ReserveSize& reserve_size) {
     ResponseStringReserve(reserve_size.size);
 }
@@ -844,8 +852,7 @@ void Session::Impl::prepareCommon() {
     if (acceptEncoding_.empty()) {
         /* enable all supported built-in compressions */
         curl_easy_setopt(curl_->handle, CURLOPT_ACCEPT_ENCODING, "");
-    }
-    else {
+    } else {
         curl_easy_setopt(curl_->handle, CURLOPT_ACCEPT_ENCODING, acceptEncoding_.getString().c_str());
     }
 #endif
@@ -948,6 +955,7 @@ void Session::SetLocalPort(const LocalPort& local_port) { pimpl_->SetLocalPort(l
 void Session::SetLocalPortRange(const LocalPortRange& local_port_range) { pimpl_->SetLocalPortRange(local_port_range); }
 void Session::SetHttpVersion(const HttpVersion& version) { pimpl_->SetHttpVersion(version); }
 void Session::SetRange(const Range& range) { pimpl_->SetRange(range); }
+void Session::SetUploadRange(const UploadRange& upload_range) { pimpl_->SetUploadRange(upload_range); }
 void Session::SetMultiRange(const MultiRange& multi_range) { pimpl_->SetMultiRange(multi_range); }
 void Session::SetReserveSize(const ReserveSize& reserve_size) { pimpl_->SetReserveSize(reserve_size); }
 void Session::SetAcceptEncoding(const AcceptEncoding& accept_encoding) { pimpl_->SetAcceptEncoding(accept_encoding); }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -611,13 +611,13 @@ void Session::Impl::SetUploadRange(const UploadRange& upload_range) {
     curl_off_t filesize = upload_range.getFilesize();
 
     // Create upload range header
-    char range_header[256];
-    sprintf(range_header,
+    std::array<char, 256> range_header;
+    sprintf(range_header.data(),
             "Content-Range: bytes %" CURL_FORMAT_CURL_OFF_T
             "-"
             "%" CURL_FORMAT_CURL_OFF_T "/*",
             resume_from, filesize - 1);
-    upload_range_header_ = std::string(range_header);
+    upload_range_header_ = std::string(range_header.data());
 
     // Set CURLOPTs
     // curl_easy_setopt(curl_->handle, CURLOPT_RESUME_FROM_LARGE, resume_from);

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -1,8 +1,11 @@
 #ifndef CPR_RANGE_H
 #define CPR_RANGE_H
 
+#include <cassert>
 #include <cstdint>
 #include <curl/curl.h>
+
+#define assertm(exp, msg) assert(((void) msg, exp))
 
 namespace cpr {
 
@@ -47,15 +50,24 @@ class MultiRange {
 
 class UploadRange : private Range {
   public:
-    UploadRange(const std::int64_t p_resume_from, const std::int64_t p_finish_at) : Range(p_resume_from, p_finish_at) {}
+    UploadRange(const std::int64_t p_resume_from, const std::int64_t p_finish_at) : Range(p_resume_from, p_finish_at) {
+        // Upload ranges do not support negative values / partial ranges
+        assertm(p_resume_from >= 0, "UploadRange does not support negative values / partial ranges");
+        assertm(p_finish_at >= 0, "UploadRange does not support negative values / partial ranges");
+        assertm(p_resume_from <= p_finish_at, "p_resume_from has to be smaller equal than p_resume_from");
+    }
 
     curl_off_t getResumeFrom() const {
         return static_cast<curl_off_t>(this->Range::getResumeFrom());
     }
 
     curl_off_t getFilesize() const {
-        return static_cast<curl_off_t>(this->Range::getFinishAt()) - this->getResumeFrom();
-        ;
+        // More information: https://curl.se/mail/lib-2019-05/0012.html
+        // filesize = resume_from + part size =
+        //          = resume_from + (finish_at - resume_from + 1)
+        //          = finish_at + 1
+        // Note: We assume that the actual filesize is larger than or equal to finish_at
+        return static_cast<curl_off_t>(this->Range::getFinishAt()) + 1;
     }
 };
 

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -2,6 +2,7 @@
 #define CPR_RANGE_H
 
 #include <cstdint>
+#include <curl/curl.h>
 
 namespace cpr {
 
@@ -9,14 +10,23 @@ class Range {
   public:
     Range(const std::int64_t p_resume_from, const std::int64_t p_finish_at) : resume_from(p_resume_from), finish_at(p_finish_at) {}
 
-    std::int64_t resume_from = 0;
-    std::int64_t finish_at = 0;
+    std::int64_t getResumeFrom() const {
+        return resume_from;
+    }
+
+    std::int64_t getFinishAt() const {
+        return finish_at;
+    }
 
     const std::string str() const {
         std::string from_str = (resume_from < (std::int64_t) 0) ? "" : std::to_string(resume_from);
         std::string to_str = (finish_at < (std::int64_t) 0) ? "" : std::to_string(finish_at);
         return from_str + "-" + to_str;
     }
+
+  private:
+    std::int64_t resume_from = 0;
+    std::int64_t finish_at = 0;
 };
 
 class MultiRange {
@@ -33,7 +43,21 @@ class MultiRange {
 
   private:
     std::vector<Range> ranges;
-}; // namespace cpr
+};
+
+class UploadRange : Range {
+  public:
+    UploadRange(const std::int64_t p_resume_from, const std::int64_t p_finish_at) : Range(p_resume_from, p_finish_at) {}
+
+    curl_off_t getResumeFrom() const {
+        return static_cast<curl_off_t>(this->Range::getResumeFrom());
+    }
+
+    curl_off_t getFilesize() const {
+        return static_cast<curl_off_t>(this->Range::getFinishAt()) - this->getResumeFrom();
+        ;
+    }
+};
 
 } // namespace cpr
 

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -45,7 +45,7 @@ class MultiRange {
     std::vector<Range> ranges;
 };
 
-class UploadRange : Range {
+class UploadRange : private Range {
   public:
     UploadRange(const std::int64_t p_resume_from, const std::int64_t p_finish_at) : Range(p_resume_from, p_finish_at) {}
 

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -138,6 +138,7 @@ class Session {
     void SetOption(const ReserveSize& reserve_size);
     void SetOption(const AcceptEncoding& accept_encoding);
     void SetOption(AcceptEncoding&& accept_encoding);
+    void SetOption(const UploadRange& upload_range);
 
     cpr_off_t GetDownloadFileLength();
     /**

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <memory>
 
+#include "cpr/accept_encoding.h"
 #include "cpr/auth.h"
 #include "cpr/bearer.h"
 #include "cpr/body.h"
@@ -13,7 +14,6 @@
 #include "cpr/cookies.h"
 #include "cpr/cprtypes.h"
 #include "cpr/curlholder.h"
-#include "cpr/accept_encoding.h"
 #include "cpr/http_version.h"
 #include "cpr/interface.h"
 #include "cpr/limit_rate.h"
@@ -90,6 +90,7 @@ class Session {
     void SetReserveSize(const ReserveSize& reserve_size);
     void SetAcceptEncoding(const AcceptEncoding& accept_encoding);
     void SetAcceptEncoding(AcceptEncoding&& accept_encoding);
+    void SetUploadRange(const UploadRange& upload_range);
 
     // Used in templated functions
     void SetOption(const Url& url);

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -1062,6 +1062,19 @@ TEST(BasicTests, AcceptEncodingTestWithCostomizedStringLValue) {
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 
+TEST(UploadRangeTests, SimpleUploadRangeTest) {
+    Url url{"http://httpbin.org/put"};
+    Session session;
+    session.SetUrl(url);
+    session.SetPayload({{"x", "5"}, {"y", "42"}});
+    session.SetUploadRange(cpr::UploadRange{0, 3});
+    Response response = session.Put();
+    std::cout << response.text;
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(server);

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -1066,21 +1066,21 @@ TEST(UploadRangeTests, UploadSingleFullRangeTest) {
     Url url{server->GetBaseUrl() + "/header_reflect.html"};
     Session session;
     session.SetUrl(url);
-    session.SetPayload({{"key", "1234"}});
-    session.SetUploadRange(cpr::UploadRange{0, 7});
+    session.SetBody("hello world");
+    session.SetUploadRange(cpr::UploadRange{0, 10});
     Response response = session.Put();
 
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
-    EXPECT_EQ(std::string{"bytes 0-7/*"}, response.header["Content-Range"]);
+    EXPECT_EQ(std::string{"bytes 0-10/*"}, response.header["Content-Range"]);
 }
 
 TEST(UploadRangeTests, UploadSingleFirstPartRangeTest) {
     Url url{server->GetBaseUrl() + "/header_reflect.html"};
     Session session;
     session.SetUrl(url);
-    session.SetPayload({{"key", "12"}});
+    session.SetBody("hello ");
     session.SetUploadRange(cpr::UploadRange{0, 5});
     Response response = session.Put();
 
@@ -1094,14 +1094,14 @@ TEST(UploadRangeTests, UploadSingleSecondPartRangeTest) {
     Url url{server->GetBaseUrl() + "/header_reflect.html"};
     Session session;
     session.SetUrl(url);
-    session.SetPayload({{"y", "1234"}});
-    session.SetUploadRange(cpr::UploadRange{2, 7});
-    Response response = session.Put();
+    session.SetBody("world");
+    session.SetUploadRange(cpr::UploadRange{6, 10});
+    Response response = session.Patch();
 
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
-    EXPECT_EQ(std::string{"bytes 2-7/*"}, response.header["Content-Range"]);
+    EXPECT_EQ(std::string{"bytes 6-10/*"}, response.header["Content-Range"]);
 }
 
 TEST(UploadRangeTests, UploadTwoPartsRangeTest) {
@@ -1122,7 +1122,7 @@ TEST(UploadRangeTests, UploadTwoPartsRangeTest) {
     // Upload second part
     session.SetBody("world");
     session.SetUploadRange(cpr::UploadRange{6, 10});
-    response = session.Put();
+    response = session.Patch();
 
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(200, response.status_code);


### PR DESCRIPTION
Issue: #745 

I have implemented the basics for uploading arbitrary file parts with CURLOPT_RESUME_FROM, like it is described [here](https://curl.se/mail/lib-2019-05/0012.html). 

Unfortunately, I have encountered a problem that I have not yet been able to solve on my own:
As implemented, all local tests are successful and header values are set correctly. However, I had to comment out the setting of the CURLOPT_RESUME_FROM option in `session.cpp`. If the option is set, requests with a set UploadRange cannot connect to the Http server. More precisely, the execution will then hang at `curl_easy_perform(curl_->handle)` in the `makeRequest()` method of `session.cpp`.

The problems occurred not only with the internal test http server, but also with a local Python server and external providers.

Unfortunately, I am currently stuck at this point and would be happy if someone could help me with this or has a suggestion what the problem might be. One of my assumptions is that the Http server simply does not support the upload of arbitrary parts and therefore the connect phase is somehow not successful. 