### PR TITLE
Add support of customized filename for Multipart (#642)

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -357,6 +357,11 @@ void Session::Impl::SetMultipart(Multipart&& multipart) {
             formdata.push_back({CURLFORM_COPYNAME, part.name.c_str()});
             if (part.is_file) {
                 formdata.push_back({CURLFORM_FILE, part.value.c_str()});
+                if (part.has_filename) {
+                    formdata.push_back({CURLFORM_FILENAME, part.filename.c_str()});
+                } else {
+                    formdata.push_back({CURLFORM_FILENAME, part.value.c_str()});
+                }
             } else {
                 formdata.push_back({CURLFORM_COPYCONTENTS, part.value.c_str()});
             }
@@ -388,6 +393,11 @@ void Session::Impl::SetMultipart(const Multipart& multipart) {
             formdata.push_back({CURLFORM_COPYNAME, part.name.c_str()});
             if (part.is_file) {
                 formdata.push_back({CURLFORM_FILE, part.value.c_str()});
+                if (part.has_filename) {
+                    formdata.push_back({CURLFORM_FILENAME, part.filename.c_str()});
+                } else {
+                    formdata.push_back({CURLFORM_FILENAME, part.value.c_str()});
+                }
             } else {
                 formdata.push_back({CURLFORM_COPYCONTENTS, part.value.c_str()});
             }
@@ -844,8 +854,7 @@ void Session::Impl::prepareCommon() {
     if (acceptEncoding_.empty()) {
         /* enable all supported built-in compressions */
         curl_easy_setopt(curl_->handle, CURLOPT_ACCEPT_ENCODING, "");
-    }
-    else {
+    } else {
         curl_easy_setopt(curl_->handle, CURLOPT_ACCEPT_ENCODING, acceptEncoding_.getString().c_str());
     }
 #endif

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -39,12 +39,14 @@ struct Buffer {
 };
 
 struct Part {
-    Part(const std::string& p_name, const std::string& p_value, const std::string& p_content_type = {}) : name{p_name}, value{p_value}, content_type{p_content_type}, is_file{false}, is_buffer{false} {}
-    Part(const std::string& p_name, const std::int32_t& p_value, const std::string& p_content_type = {}) : name{p_name}, value{std::to_string(p_value)}, content_type{p_content_type}, is_file{false}, is_buffer{false} {}
-    Part(const std::string& p_name, const File& file, const std::string& p_content_type = {}) : name{p_name}, value{file.filepath}, content_type{p_content_type}, is_file{true}, is_buffer{false} {}
-    Part(const std::string& p_name, const Buffer& buffer, const std::string& p_content_type = {}) : name{p_name}, value{buffer.filename}, content_type{p_content_type}, data{buffer.data}, datalen{buffer.datalen}, is_file{false}, is_buffer{true} {}
+    Part(const std::string& p_name, const std::string& p_value, const std::string& p_content_type = {}) : name{p_name}, value{p_value}, content_type{p_content_type}, is_file{false}, is_buffer{false}, has_filename{false} {}
+    Part(const std::string& p_name, const std::int32_t& p_value, const std::string& p_content_type = {}) : name{p_name}, value{std::to_string(p_value)}, content_type{p_content_type}, is_file{false}, is_buffer{false}, has_filename{false} {}
+    Part(const std::string& p_name, const File& file, const std::string& p_content_type = {}) : name{p_name}, value{file.filepath}, content_type{p_content_type}, is_file{true}, is_buffer{false}, has_filename{false} {}
+    Part(const std::string& p_name, const std::string& p_filename, const File& file, const std::string& p_content_type = {}) : name{p_name}, filename{p_filename}, value{file.filepath}, content_type{p_content_type}, is_file{true}, is_buffer{false}, has_filename{true} {}
+    Part(const std::string& p_name, const Buffer& buffer, const std::string& p_content_type = {}) : name{p_name}, value{buffer.filename}, content_type{p_content_type}, data{buffer.data}, datalen{buffer.datalen}, is_file{false}, is_buffer{true}, has_filename{false} {}
 
     std::string name;
+    std::string filename;
     std::string value;
     std::string content_type;
     Buffer::data_t data{nullptr};
@@ -53,6 +55,7 @@ struct Part {
     long datalen{0};
     bool is_file;
     bool is_buffer;
+    bool has_filename;
 };
 
 class Multipart {

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -144,8 +144,32 @@ TEST(UrlEncodedPostTests, FormPostFileTest) {
     Response response = cpr::Post(url, Multipart{{"x", File{filename}}});
     std::string expected_text{
             "{\n"
-            "  \"x\": " +
+            "  \"x\": test_file=" +
             content +
+            "\n"
+            "}"};
+    std::remove(filename.c_str());
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(UrlEncodedPostTests, FormPostFileTestWithOverridedFilename) {
+    std::string filename{"test_file"};
+    std::string overided_filename{"overided_filename"};
+    std::string content{"hello world"};
+    std::ofstream test_file;
+    test_file.open(filename);
+    test_file << content;
+    test_file.close();
+    Url url{server->GetBaseUrl() + "/form_post.html"};
+    Response response = cpr::Post(url, Multipart{{"x", overided_filename, File{filename}}});
+    std::string expected_text{
+            "{\n"
+            "  \"x\": " +
+            overided_filename + "=" + content +
             "\n"
             "}"};
     std::remove(filename.c_str());
@@ -168,8 +192,33 @@ TEST(UrlEncodedPostTests, FormPostFileNoCopyTest) {
     Response response = cpr::Post(url, multipart);
     std::string expected_text{
             "{\n"
-            "  \"x\": " +
+            "  \"x\": test_file=" +
             content +
+            "\n"
+            "}"};
+    std::remove(filename.c_str());
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(UrlEncodedPostTests, FormPostFileNoCopyTestWithOverridedFilename) {
+    std::string filename{"test_file"};
+    std::string overided_filename{"overided_filename"};
+    std::string content{"hello world"};
+    std::ofstream test_file;
+    test_file.open(filename);
+    test_file << content;
+    test_file.close();
+    Url url{server->GetBaseUrl() + "/form_post.html"};
+    Multipart multipart{{"x", overided_filename, File{filename}}};
+    Response response = cpr::Post(url, multipart);
+    std::string expected_text{
+            "{\n"
+            "  \"x\": " +
+            overided_filename + "=" + content +
             "\n"
             "}"};
     std::remove(filename.c_str());
@@ -198,7 +247,7 @@ TEST(UrlEncodedPostTests, FormPostFileBufferTest) {
     Response response = cpr::Post(url, Multipart{{"x", Buffer{content.begin(), content.end(), "test_file"}}});
     std::string expected_text{
             "{\n"
-            "  \"x\": " +
+            "  \"x\": test_file=" +
             content +
             "\n"
             "}"};
@@ -216,7 +265,7 @@ TEST(UrlEncodedPostTests, FormPostFileBufferNoCopyTest) {
     Response response = cpr::Post(url, multipart);
     std::string expected_text{
             "{\n"
-            "  \"x\": " +
+            "  \"x\": test_file=" +
             content +
             "\n"
             "}"};
@@ -233,7 +282,7 @@ TEST(UrlEncodedPostTests, FormPostFileBufferPointerTest) {
     Response response = cpr::Post(url, Multipart{{"x", Buffer{content, 11 + content, "test_file"}}});
     std::string expected_text{
             "{\n"
-            "  \"x\": " +
+            "  \"x\": test_file=" +
             std::string(content) +
             "\n"
             "}"};
@@ -251,7 +300,7 @@ TEST(UrlEncodedPostTests, FormPostFileBufferArrayTest) {
     Response response = cpr::Post(url, Multipart{{"x", Buffer{std::begin(content), std::end(content) - 1, "test_file"}}});
     std::string expected_text{
             "{\n"
-            "  \"x\": " +
+            "  \"x\": test_file=" +
             std::string(content) +
             "\n"
             "}"};
@@ -268,7 +317,7 @@ TEST(UrlEncodedPostTests, FormPostFileBufferVectorTest) {
     Response response = cpr::Post(url, Multipart{{"x", Buffer{content.begin(), content.end(), "test_file"}}});
     std::string expected_text{
             "{\n"
-            "  \"x\": hello world\n"
+            "  \"x\": test_file=hello world\n"
             "}"};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
@@ -283,7 +332,7 @@ TEST(UrlEncodedPostTests, FormPostFileBufferStdArrayTest) {
     Response response = cpr::Post(url, Multipart{{"x", Buffer{content.begin(), content.end(), "test_file"}}});
     std::string expected_text{
             "{\n"
-            "  \"x\": hello world\n"
+            "  \"x\": test_file=hello world\n"
             "}"};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);


### PR DESCRIPTION
1. Add a new overloading initializer of the Part struct for `overloaded_filename`. 
2. Modify the logic of the mocking server for unit tests. 
3. Add 2 new unit tests for file uploading. 