### PR TITLE
Reduced the number of curl.h includes

### DIFF
--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -1,4 +1,5 @@
 #include "cpr/cookies.h"
+#include "cpr/curlholder.h"
 
 namespace cpr {
 std::string Cookies::GetEncoded(const CurlHolder& holder) const {

--- a/cpr/curl_container.cpp
+++ b/cpr/curl_container.cpp
@@ -1,4 +1,5 @@
 #include "cpr/curl_container.h"
+#include "cpr/curlholder.h"
 #include <algorithm>
 #include <iterator>
 

--- a/cpr/proxyauth.cpp
+++ b/cpr/proxyauth.cpp
@@ -1,6 +1,10 @@
 #include "cpr/proxyauth.h"
+#include "cpr/util.h"
 
 namespace cpr {
+EncodedAuthentication::EncodedAuthentication(const std::string& username, const std::string& password) : auth_string_{cpr::util::urlEncode(username) + ":" + cpr::util::urlEncode(password)} {}
+EncodedAuthentication::EncodedAuthentication(std::string&& username, std::string&& password) : auth_string_{cpr::util::urlEncode(username) + ":" + cpr::util::urlEncode(password)} {}
+
 const char* EncodedAuthentication::GetAuthString() const noexcept {
     return auth_string_.c_str();
 }

--- a/cpr/response.cpp
+++ b/cpr/response.cpp
@@ -1,4 +1,6 @@
 #include "cpr/response.h"
+#include "cpr/curlholder.h"
+#include "cpr/util.h"
 
 namespace cpr {
 Response::Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text, std::string&& p_header_string, Cookies&& p_cookies = Cookies{}, Error&& p_error = Error{}) : curl_(std::move(curl)), text(std::move(p_text)), cookies(std::move(p_cookies)), error(std::move(p_error)), raw_header(std::move(p_header_string)) {

--- a/include/cpr/cookies.h
+++ b/include/cpr/cookies.h
@@ -1,13 +1,18 @@
 #ifndef CPR_COOKIES_H
 #define CPR_COOKIES_H
 
-#include "cpr/curlholder.h"
 #include <initializer_list>
 #include <map>
 #include <sstream>
 #include <string>
 
 namespace cpr {
+
+/**
+ * Forward declared to prevent too many curl.h includes in header files.
+ * For reference see: https://github.com/libcpr/cpr/issues/752
+ **/
+struct CurlHolder;
 
 class Cookies {
   public:

--- a/include/cpr/curl_container.h
+++ b/include/cpr/curl_container.h
@@ -6,10 +6,14 @@
 #include <string>
 #include <vector>
 
-#include "cpr/curlholder.h"
-
 
 namespace cpr {
+
+/**
+ * Forward declared to prevent too many curl.h includes in header files.
+ * For reference see: https://github.com/libcpr/cpr/issues/752
+ **/
+struct CurlHolder;
 
 struct Parameter {
     Parameter(const std::string& p_key, const std::string& p_value) : key{p_key}, value{p_value} {}

--- a/include/cpr/curlholder.h
+++ b/include/cpr/curlholder.h
@@ -5,6 +5,9 @@
 #include <mutex>
 #include <string>
 
+/**
+ * Required for CURL can not be forward declared.
+ **/
 #include <curl/curl.h>
 
 namespace cpr {

--- a/include/cpr/proxyauth.h
+++ b/include/cpr/proxyauth.h
@@ -5,14 +5,13 @@
 #include <map>
 
 #include "cpr/auth.h"
-#include "cpr/util.h"
 
 namespace cpr {
 class EncodedAuthentication {
   public:
-    EncodedAuthentication() : auth_string_{""} {}
-    EncodedAuthentication(const std::string& username, const std::string& password) : auth_string_{cpr::util::urlEncode(username) + ":" + cpr::util::urlEncode(password)} {}
-    EncodedAuthentication(std::string&& username, std::string&& password) : auth_string_{cpr::util::urlEncode(std::move(username)) + ":" + cpr::util::urlEncode(std::move(password))} {}
+    EncodedAuthentication() = default;
+    EncodedAuthentication(const std::string& username, const std::string& password);
+    EncodedAuthentication(std::string&& username, std::string&& password);
     EncodedAuthentication(const EncodedAuthentication& other) = default;
     EncodedAuthentication(EncodedAuthentication&& old) noexcept = default;
     virtual ~EncodedAuthentication() noexcept = default;

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -12,7 +12,6 @@
 #include "cpr/cprtypes.h"
 #include "cpr/error.h"
 #include "cpr/ssl_options.h"
-#include "cpr/util.h"
 
 namespace cpr {
 

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <memory>
 
+#include "cpr/accept_encoding.h"
 #include "cpr/auth.h"
 #include "cpr/bearer.h"
 #include "cpr/body.h"
@@ -12,8 +13,6 @@
 #include "cpr/connect_timeout.h"
 #include "cpr/cookies.h"
 #include "cpr/cprtypes.h"
-#include "cpr/curlholder.h"
-#include "cpr/accept_encoding.h"
 #include "cpr/http_version.h"
 #include "cpr/interface.h"
 #include "cpr/limit_rate.h"
@@ -36,6 +35,12 @@
 #include "cpr/verbose.h"
 
 namespace cpr {
+
+/**
+ * Forward declared to prevent too many curl.h includes in header files.
+ * For reference see: https://github.com/libcpr/cpr/issues/752
+ **/
+struct CurlHolder;
 
 class Interceptor;
 

--- a/include/cpr/ssl_ctx.h
+++ b/include/cpr/ssl_ctx.h
@@ -2,6 +2,9 @@
 #define CPR_SSL_CTX_H
 
 #include "cpr/ssl_options.h"
+/**
+ * Required for CURLcode can not be forward declared.
+ **/
 #include <curl/curl.h>
 
 #if SUPPORT_CURLOPT_SSL_CTX_FUNCTION

--- a/include/cpr/ssl_options.h
+++ b/include/cpr/ssl_options.h
@@ -3,11 +3,13 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+/**
+ * Required for CURL_SSLVERSION_DEFAULT can not be forward declared.
+ **/
 #include <curl/curl.h>
-
-#include <utility>
 
 #define __LIBCURL_VERSION_GTE(major, minor) ((LIBCURL_VERSION_MAJOR > (major)) || ((LIBCURL_VERSION_MAJOR == (major)) && (LIBCURL_VERSION_MINOR >= (minor))))
 #define __LIBCURL_VERSION_LT(major, minor) ((LIBCURL_VERSION_MAJOR < (major)) || ((LIBCURL_VERSION_MAJOR == (major)) && (LIBCURL_VERSION_MINOR < (minor))))

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -10,9 +10,13 @@
 #include "cpr/cprtypes.h"
 #include "cpr/curlholder.h"
 
+/**
+ * Required for CURL can not be forward declared.
+ **/
+#include <curl/curl.h>
+
 namespace cpr {
 namespace util {
-
 Header parseHeader(const std::string& headers, std::string* status_line = nullptr, std::string* reason = nullptr);
 Cookies parseCookies(curl_slist* raw_cookies);
 size_t readUserFunction(char* ptr, size_t size, size_t nitems, const ReadCallback* read);

--- a/test/structures_tests.cpp
+++ b/test/structures_tests.cpp
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include <cpr/curlholder.h>
 #include <cpr/parameters.h>
 #include <cpr/payload.h>
 


### PR DESCRIPTION
This PR reduces the number of transitive `curl.h` includes in cpr for https://github.com/libcpr/cpr/issues/752