### PR TITLE
Implement curl_multi_perform

### DIFF
--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -24,7 +24,8 @@ add_library(cpr
         response.cpp
         redirect.cpp
         interceptor.cpp
-        ssl_ctx.cpp)
+        ssl_ctx.cpp
+        curlmultiholder.cpp)
 
 add_library(cpr::cpr ALIAS cpr)
 

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(cpr
         redirect.cpp
         interceptor.cpp
         ssl_ctx.cpp
-        curlmultiholder.cpp)
+        curlmultiholder.cpp
+        multiperform.cpp)
 
 add_library(cpr::cpr ALIAS cpr)
 

--- a/cpr/curlmultiholder.cpp
+++ b/cpr/curlmultiholder.cpp
@@ -4,8 +4,7 @@
 
 namespace cpr {
 
-CurlMultiHolder::CurlMultiHolder() {
-    handle = curl_multi_init();
+CurlMultiHolder::CurlMultiHolder() : handle{curl_multi_init()} {
     assert(handle);
 }
 

--- a/cpr/curlmultiholder.cpp
+++ b/cpr/curlmultiholder.cpp
@@ -1,0 +1,16 @@
+#include "cpr/curlmultiholder.h"
+
+#include <cassert>
+
+namespace cpr {
+
+CurlMultiHolder::CurlMultiHolder() {
+    handle = curl_multi_init();
+    assert(handle);
+}
+
+CurlMultiHolder::~CurlMultiHolder() {
+    curl_multi_cleanup(handle);
+}
+
+} // namespace cpr

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -46,7 +46,7 @@ void MultiPerform::DoMultiPerform() {
         }
 
         if (still_running) {
-            int timeout_ms = 1000;
+            const int timeout_ms{1000};
             error_code = curl_multi_poll(multicurl_->handle, nullptr, 0, timeout_ms, nullptr);
             if (error_code) {
                 fprintf(stderr, "curl_multi_poll() failed, code %d.\n", static_cast<int>(error_code));

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -14,6 +14,9 @@ void MultiPerform::AddSession(std::shared_ptr<Session>& session) {
         return;
     }
 
+    // Lock session to the multihandle
+    session->isUsedInMultiPerform = true;
+
     // Add session to sessions_
     sessions_.push_back(session);
 }

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -27,7 +27,7 @@ void MultiPerform::AddSession(std::shared_ptr<Session>& session, HttpMethod meth
     // Add easy handle to multi handle
     CURLMcode error_code = curl_multi_add_handle(multicurl_->handle, session->curl_->handle);
     if (error_code) {
-        fprintf(stderr, "curl_multi_add_handle() failed, code %d.\n", static_cast<int>(error_code));
+        (void) fprintf(stderr, "curl_multi_add_handle() failed, code %d.\n", static_cast<int>(error_code));
         return;
     }
 
@@ -42,7 +42,7 @@ void MultiPerform::RemoveSession(const std::shared_ptr<Session>& session) {
     // Remove easy handle from multihandle
     CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, session->curl_->handle);
     if (error_code) {
-        fprintf(stderr, "curl_multi_remove_handle() failed, code %d.\n", static_cast<int>(error_code));
+        (void) fprintf(stderr, "curl_multi_remove_handle() failed, code %d.\n", static_cast<int>(error_code));
         return;
     }
 
@@ -68,7 +68,7 @@ void MultiPerform::DoMultiPerform() {
     do {
         CURLMcode error_code = curl_multi_perform(multicurl_->handle, &still_running);
         if (error_code) {
-            fprintf(stderr, "curl_multi_perform() failed, code %d.\n", static_cast<int>(error_code));
+            (void) fprintf(stderr, "curl_multi_perform() failed, code %d.\n", static_cast<int>(error_code));
             break;
         }
 
@@ -76,7 +76,7 @@ void MultiPerform::DoMultiPerform() {
             const int timeout_ms{1000};
             error_code = curl_multi_poll(multicurl_->handle, nullptr, 0, timeout_ms, nullptr);
             if (error_code) {
-                fprintf(stderr, "curl_multi_poll() failed, code %d.\n", static_cast<int>(error_code));
+                (void) fprintf(stderr, "curl_multi_poll() failed, code %d.\n", static_cast<int>(error_code));
                 break;
             }
         }
@@ -97,7 +97,7 @@ std::vector<Response> MultiPerform::ReadMultiInfo(std::function<Response(Session
             // Find current session
             auto it = std::find_if(sessions_.begin(), sessions_.end(), [&info](const std::pair<std::shared_ptr<Session>, HttpMethod>& pair) { return pair.first->curl_->handle == info->easy_handle; });
             if (it == sessions_.end()) {
-                fprintf(stderr, "Failed to find current session!\n");
+                (void) fprintf(stderr, "Failed to find current session!\n");
                 break;
             }
             std::shared_ptr<Session> current_session = (*it).first;
@@ -157,7 +157,7 @@ void MultiPerform::PrepareSessions() {
                 pair.first->PrepareOptions();
                 break;
             default:
-                fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or download without arguments!\n");
+                (void) fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or download without arguments!\n");
                 return;
         }
     }
@@ -170,7 +170,7 @@ void MultiPerform::PrepareDownloadSession(size_t sessions_index, const WriteCall
             pair.first->PrepareDownload(write);
             break;
         default:
-            fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!\n");
+            (void) fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!\n");
             return;
     }
 }
@@ -182,7 +182,7 @@ void MultiPerform::PrepareDownloadSession(size_t sessions_index, std::ofstream& 
             pair.first->PrepareDownload(file);
             break;
         default:
-            fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!\n");
+            (void) fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!\n");
             return;
     }
 }

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -89,7 +89,7 @@ std::vector<Response> MultiPerform::MakeRequest() {
 }
 
 void MultiPerform::PrepareGet() {
-    for (std::shared_ptr<Session> session : sessions_) {
+    for (std::shared_ptr<Session>& session : sessions_) {
         session->PrepareGet();
     }
 }

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -59,7 +59,7 @@ void MultiPerform::DoMultiPerform() {
 std::vector<Response> MultiPerform::ReadMultiInfo() {
     // Get infos and create Response objects
     std::vector<Response> responses;
-    struct CURLMsg* info;
+    struct CURLMsg* info{nullptr};
     do {
         int msgq = 0;
 

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -18,7 +18,7 @@ void MultiPerform::AddSession(std::shared_ptr<Session>& session) {
     sessions_.push_back(session);
 }
 
-void MultiPerform::RemoveSession(std::shared_ptr<Session>& session) {
+void MultiPerform::RemoveSession(const std::shared_ptr<Session>& session) {
     // Remove easy handle from multihandle
     CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, session->curl_->handle);
     if (error_code) {

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -46,7 +46,8 @@ void MultiPerform::DoMultiPerform() {
         }
 
         if (still_running) {
-            error_code = curl_multi_poll(multicurl_->handle, nullptr, 0, 1000, nullptr);
+            int timeout_ms = 1000;
+            error_code = curl_multi_poll(multicurl_->handle, nullptr, 0, timeout_ms, nullptr);
             if (error_code) {
                 fprintf(stderr, "curl_multi_poll() failed, code %d.\n", static_cast<int>(error_code));
                 break;

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -8,7 +8,7 @@ MultiPerform::MultiPerform() : multicurl_(new CurlMultiHolder()) {}
 
 void MultiPerform::AddSession(std::shared_ptr<Session>& session, HttpMethod method) {
     // Check if this multiperform is download only
-    if (((method != HttpMethod::DOWNLOAD_REQUEST && is_download_multi_perform) && method != HttpMethod::UNDEFINED) || (method == HttpMethod::DOWNLOAD_REQUEST && !is_download_multi_perform && sessions_.size() >= 1)) {
+    if (((method != HttpMethod::DOWNLOAD_REQUEST && is_download_multi_perform) && method != HttpMethod::UNDEFINED) || (method == HttpMethod::DOWNLOAD_REQUEST && !is_download_multi_perform && !sessions_.empty())) {
         throw std::invalid_argument("Failed to add session: Cannot mix download and non-download methods!");
     }
 

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -76,6 +76,7 @@ std::vector<Response> MultiPerform::ReadMultiInfo() {
             std::shared_ptr<Session> current_session = *it;
 
             // Add response object
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-union-access)
             responses.push_back(current_session->Complete(info->data.result));
         }
     } while (info);

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -1,6 +1,7 @@
 #include "cpr/multiperform.h"
 
 #include <algorithm>
+#include <iostream>
 
 namespace cpr {
 
@@ -28,7 +29,7 @@ void MultiPerform::AddSession(std::shared_ptr<Session>& session, HttpMethod meth
     // Add easy handle to multi handle
     CURLMcode error_code = curl_multi_add_handle(multicurl_->handle, session->curl_->handle);
     if (error_code) {
-        (void) fprintf(stderr, "curl_multi_add_handle() failed, code %d.\n", static_cast<int>(error_code));
+        std::cerr << "curl_multi_add_handle() failed, code " << static_cast<int>(error_code) << std::endl;
         return;
     }
 
@@ -43,7 +44,7 @@ void MultiPerform::RemoveSession(const std::shared_ptr<Session>& session) {
     // Remove easy handle from multihandle
     CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, session->curl_->handle);
     if (error_code) {
-        (void) fprintf(stderr, "curl_multi_remove_handle() failed, code %d.\n", static_cast<int>(error_code));
+        std::cerr << "curl_multi_remove_handle() failed, code " << static_cast<int>(error_code) << std::endl;
         return;
     }
 
@@ -69,7 +70,7 @@ void MultiPerform::DoMultiPerform() {
     do {
         CURLMcode error_code = curl_multi_perform(multicurl_->handle, &still_running);
         if (error_code) {
-            (void) fprintf(stderr, "curl_multi_perform() failed, code %d.\n", static_cast<int>(error_code));
+            std::cerr << "curl_multi_perform() failed, code " << static_cast<int>(error_code) << std::endl;
             break;
         }
 
@@ -77,7 +78,7 @@ void MultiPerform::DoMultiPerform() {
             const int timeout_ms{1000};
             error_code = curl_multi_poll(multicurl_->handle, nullptr, 0, timeout_ms, nullptr);
             if (error_code) {
-                (void) fprintf(stderr, "curl_multi_poll() failed, code %d.\n", static_cast<int>(error_code));
+                std::cerr << "curl_multi_poll() failed, code " << static_cast<int>(error_code) << std::endl;
                 break;
             }
         }
@@ -98,7 +99,7 @@ std::vector<Response> MultiPerform::ReadMultiInfo(std::function<Response(Session
             // Find current session
             auto it = std::find_if(sessions_.begin(), sessions_.end(), [&info](const std::pair<std::shared_ptr<Session>, HttpMethod>& pair) { return pair.first->curl_->handle == info->easy_handle; });
             if (it == sessions_.end()) {
-                (void) fprintf(stderr, "Failed to find current session!\n");
+                std::cerr << "Failed to find current session!" << std::endl;
                 break;
             }
             std::shared_ptr<Session> current_session = (*it).first;
@@ -158,7 +159,7 @@ void MultiPerform::PrepareSessions() {
                 pair.first->PrepareOptions();
                 break;
             default:
-                (void) fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or download without arguments!\n");
+                std::cerr << "PrepareSessions failed: Undefined HttpMethod or download without arguments!" << std::endl;
                 return;
         }
     }
@@ -171,7 +172,7 @@ void MultiPerform::PrepareDownloadSession(size_t sessions_index, const WriteCall
             pair.first->PrepareDownload(write);
             break;
         default:
-            (void) fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!\n");
+            std::cerr << "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!" << std::endl;
             return;
     }
 }
@@ -183,7 +184,7 @@ void MultiPerform::PrepareDownloadSession(size_t sessions_index, std::ofstream& 
             pair.first->PrepareDownload(file);
             break;
         default:
-            (void) fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!\n");
+            std::cerr << "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!" << std::endl;
             return;
     }
 }

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -8,7 +8,7 @@ MultiPerform::MultiPerform() : multicurl_(new CurlMultiHolder()) {}
 
 void MultiPerform::AddSession(std::shared_ptr<Session>& session, HttpMethod method) {
     // Check if this multiperform is download only
-    if ((method != HttpMethod::DOWNLOAD_REQUEST && is_download_multi_perform) && method != HttpMethod::UNDEFINED) {
+    if (((method != HttpMethod::DOWNLOAD_REQUEST && is_download_multi_perform) && method != HttpMethod::UNDEFINED) || (method == HttpMethod::DOWNLOAD_REQUEST && !is_download_multi_perform && sessions_.size() >= 1)) {
         throw std::invalid_argument("Failed to add session: Cannot mix download and non-download methods!");
     }
 

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -16,6 +16,7 @@ MultiPerform::~MultiPerform() {
 void MultiPerform::AddSession(std::shared_ptr<Session>& session, HttpMethod method) {
     // Check if this multiperform is download only
     if (((method != HttpMethod::DOWNLOAD_REQUEST && is_download_multi_perform) && method != HttpMethod::UNDEFINED) || (method == HttpMethod::DOWNLOAD_REQUEST && !is_download_multi_perform && !sessions_.empty())) {
+        // Currently it is not possible to mix download and non-download methods, as download needs additional parameters
         throw std::invalid_argument("Failed to add session: Cannot mix download and non-download methods!");
     }
 

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -147,6 +147,36 @@ void MultiPerform::PrepareSessions() {
     }
 }
 
+void MultiPerform::PrepareDownloadSession(size_t sessions_index, const WriteCallback& write) {
+    if (sessions_index >= sessions_.size()) {
+        return;
+    }
+    std::pair<std::shared_ptr<Session>, HttpMethod>& pair = sessions_[sessions_index];
+    switch (pair.second) {
+        case HttpMethod::DOWNLOAD_REQUEST:
+            pair.first->PrepareDownload(write);
+            break;
+        default:
+            fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!\n");
+            return;
+    }
+}
+
+void MultiPerform::PrepareDownloadSession(size_t sessions_index, std::ofstream& file) {
+    if (sessions_index >= sessions_.size()) {
+        return;
+    }
+    std::pair<std::shared_ptr<Session>, HttpMethod>& pair = sessions_[sessions_index];
+    switch (pair.second) {
+        case HttpMethod::DOWNLOAD_REQUEST:
+            pair.first->PrepareDownload(file);
+            break;
+        default:
+            fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!\n");
+            return;
+    }
+}
+
 void MultiPerform::SetHttpMethod(HttpMethod method) {
     for (std::pair<std::shared_ptr<Session>, HttpMethod>& pair : sessions_) {
         pair.second = method;

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -1,0 +1,101 @@
+#include "cpr/multiperform.h"
+
+namespace cpr {
+
+MultiPerform::MultiPerform() : multicurl_(new CurlMultiHolder()) {}
+
+void MultiPerform::AddSession(std::shared_ptr<Session> session) {
+    // Add easy handle to multi handle
+    CURLMcode error_code = curl_multi_add_handle(multicurl_->handle, session->curl_->handle);
+    if (error_code) {
+        fprintf(stderr, "curl_multi_add_handle() failed, code %d.\n", (int) error_code);
+        return;
+    }
+
+    // Add session to sessions_
+    sessions_.push_back(session);
+}
+
+void MultiPerform::RemoveSession(std::shared_ptr<Session> session) {
+    // Remove easy handle from multihandle
+    CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, session->curl_->handle);
+    if (error_code) {
+        fprintf(stderr, "curl_multi_remove_handle() failed, code %d.\n", (int) error_code);
+        return;
+    }
+
+    // Remove session from sessions_
+    for (auto it = sessions_.begin(); it != sessions_.end(); ++it) {
+        if (session->curl_->handle == (*it)->curl_->handle) {
+            sessions_.erase(it);
+            break;
+        }
+    }
+}
+
+void MultiPerform::DoMultiPerform() {
+    // Do multi perform until every handle has finished
+    int still_running{0};
+    CURLMcode error_code;
+    do {
+        error_code = curl_multi_perform(multicurl_->handle, &still_running);
+        if (error_code) {
+            fprintf(stderr, "curl_multi_perform() failed, code %d.\n", (int) error_code);
+            break;
+        }
+
+        if (still_running) {
+            error_code = curl_multi_poll(multicurl_->handle, NULL, 0, 1000, NULL);
+            if (error_code) {
+                fprintf(stderr, "curl_multi_poll() failed, code %d.\n", (int) error_code);
+                break;
+            }
+        }
+    } while (still_running);
+}
+
+std::vector<Response> MultiPerform::ReadMultiInfo() {
+    // Get infos and create Response objects
+    std::vector<Response> responses;
+    struct CURLMsg* info;
+    do {
+        int msgq = 0;
+
+        // Read info from multihandle
+        info = curl_multi_info_read(multicurl_->handle, &msgq);
+
+        if (info) {
+            // Find current session
+            std::shared_ptr<Session> current_session;
+            for (std::shared_ptr<Session> session : sessions_) {
+                if (session->curl_->handle == info->easy_handle) {
+                    current_session = session;
+                    break;
+                }
+            }
+
+            // Add response object
+            responses.push_back(current_session->Complete(info->data.result));
+        }
+    } while (info);
+
+    return responses;
+}
+
+std::vector<Response> MultiPerform::MakeRequest() {
+    DoMultiPerform();
+    return ReadMultiInfo();
+}
+
+void MultiPerform::PrepareGet() {
+    for (std::shared_ptr<Session> session : sessions_) {
+        session->PrepareGet();
+    }
+}
+
+std::vector<Response> MultiPerform::Get() {
+    PrepareGet();
+    return MakeRequest();
+}
+
+} // namespace cpr

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -148,9 +148,6 @@ void MultiPerform::PrepareSessions() {
 }
 
 void MultiPerform::PrepareDownloadSession(size_t sessions_index, const WriteCallback& write) {
-    if (sessions_index >= sessions_.size()) {
-        return;
-    }
     std::pair<std::shared_ptr<Session>, HttpMethod>& pair = sessions_[sessions_index];
     switch (pair.second) {
         case HttpMethod::DOWNLOAD_REQUEST:
@@ -163,9 +160,6 @@ void MultiPerform::PrepareDownloadSession(size_t sessions_index, const WriteCall
 }
 
 void MultiPerform::PrepareDownloadSession(size_t sessions_index, std::ofstream& file) {
-    if (sessions_index >= sessions_.size()) {
-        return;
-    }
     std::pair<std::shared_ptr<Session>, HttpMethod>& pair = sessions_[sessions_index];
     switch (pair.second) {
         case HttpMethod::DOWNLOAD_REQUEST:

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -75,7 +75,7 @@ void MultiPerform::DoMultiPerform() {
         }
 
         if (still_running) {
-            const int timeout_ms{1000};
+            const int timeout_ms{250};
             error_code = curl_multi_poll(multicurl_->handle, nullptr, 0, timeout_ms, nullptr);
             if (error_code) {
                 std::cerr << "curl_multi_poll() failed, code " << static_cast<int>(error_code) << std::endl;

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -114,6 +114,7 @@ std::vector<Response> MultiPerform::ReadMultiInfo(std::function<Response(Session
         Session& current_session = *(pair.first);
         auto it = std::find_if(responses.begin(), responses.end(), [&current_session](const Response& response) { return current_session.curl_->handle == response.curl_->handle; });
         Response current_response = *it;
+        // Erase response from original vector to increase future search speed
         responses.erase(it);
         sorted_responses.push_back(current_response);
     }

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -29,10 +29,13 @@ void MultiPerform::RemoveSession(const std::shared_ptr<Session>& session) {
         return;
     }
 
+    // Unock session
+    session->isUsedInMultiPerform = false;
+
     // Remove session from sessions_
     auto it = std::find_if(sessions_.begin(), sessions_.end(), [&session](const std::shared_ptr<Session>& current_session) { return session->curl_->handle == current_session->curl_->handle; });
     if (it == sessions_.end()) {
-        fprintf(stderr, "Failed to find session!");
+        fprintf(stderr, "Failed to find session!\n");
         return;
     }
     sessions_.erase(it);
@@ -73,7 +76,7 @@ std::vector<Response> MultiPerform::ReadMultiInfo() {
             // Find current session
             auto it = std::find_if(sessions_.begin(), sessions_.end(), [&info](const std::shared_ptr<Session>& session) { return session->curl_->handle == info->easy_handle; });
             if (it == sessions_.end()) {
-                fprintf(stderr, "Failed to find current session!");
+                fprintf(stderr, "Failed to find current session!\n");
                 break;
             }
             std::shared_ptr<Session> current_session = *it;

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -38,9 +38,8 @@ void MultiPerform::RemoveSession(const std::shared_ptr<Session>& session) {
 void MultiPerform::DoMultiPerform() {
     // Do multi perform until every handle has finished
     int still_running{0};
-    CURLMcode error_code;
     do {
-        error_code = curl_multi_perform(multicurl_->handle, &still_running);
+        CURLMcode error_code = curl_multi_perform(multicurl_->handle, &still_running);
         if (error_code) {
             fprintf(stderr, "curl_multi_perform() failed, code %d.\n", static_cast<int>(error_code));
             break;

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -9,8 +9,7 @@ MultiPerform::MultiPerform() : multicurl_(new CurlMultiHolder()) {}
 void MultiPerform::AddSession(std::shared_ptr<Session>& session, HttpMethod method) {
     // Check if this multiperform is download only
     if ((method != HttpMethod::DOWNLOAD_REQUEST && is_download_multi_perform) && method != HttpMethod::UNDEFINED) {
-        fprintf(stderr, "Failed to add session: Cannot mix download and non-download methods!\n");
-        return;
+        throw std::invalid_argument("Failed to add session: Cannot mix download and non-download methods!");
     }
 
     // Set download only if neccessary
@@ -46,8 +45,7 @@ void MultiPerform::RemoveSession(const std::shared_ptr<Session>& session) {
     // Remove session from sessions_
     auto it = std::find_if(sessions_.begin(), sessions_.end(), [&session](const std::pair<std::shared_ptr<Session>, HttpMethod>& pair) { return session->curl_->handle == pair.first->curl_->handle; });
     if (it == sessions_.end()) {
-        fprintf(stderr, "Failed to find session!\n");
-        return;
+        throw std::invalid_argument("Failed to find session!");
     }
     sessions_.erase(it);
 

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -6,6 +6,13 @@ namespace cpr {
 
 MultiPerform::MultiPerform() : multicurl_(new CurlMultiHolder()) {}
 
+MultiPerform::~MultiPerform() {
+    // Unock all sessions
+    for (std::pair<std::shared_ptr<Session>, HttpMethod> pair : sessions_) {
+        pair.first->isUsedInMultiPerform = false;
+    }
+}
+
 void MultiPerform::AddSession(std::shared_ptr<Session>& session, HttpMethod method) {
     // Check if this multiperform is download only
     if (((method != HttpMethod::DOWNLOAD_REQUEST && is_download_multi_perform) && method != HttpMethod::UNDEFINED) || (method == HttpMethod::DOWNLOAD_REQUEST && !is_download_multi_perform && !sessions_.empty())) {

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -29,7 +29,7 @@ void MultiPerform::AddSession(std::shared_ptr<Session>& session, HttpMethod meth
     session->isUsedInMultiPerform = true;
 
     // Add session to sessions_
-    sessions_.push_back({session, method});
+    sessions_.emplace_back(session, method);
 }
 
 void MultiPerform::RemoveSession(const std::shared_ptr<Session>& session) {

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -8,7 +8,7 @@ MultiPerform::MultiPerform() : multicurl_(new CurlMultiHolder()) {}
 
 MultiPerform::~MultiPerform() {
     // Unock all sessions
-    for (std::pair<std::shared_ptr<Session>, HttpMethod> pair : sessions_) {
+    for (std::pair<std::shared_ptr<Session>, HttpMethod>& pair : sessions_) {
         pair.first->isUsedInMultiPerform = false;
     }
 }

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -108,7 +108,17 @@ std::vector<Response> MultiPerform::ReadMultiInfo(std::function<Response(Session
         }
     } while (info);
 
-    return responses;
+    // Sort response objects to match order of added sessions
+    std::vector<Response> sorted_responses;
+    for (std::pair<std::shared_ptr<Session>, HttpMethod>& pair : sessions_) {
+        Session& current_session = *(pair.first);
+        auto it = std::find_if(responses.begin(), responses.end(), [&current_session](const Response& response) { return current_session.curl_->handle == response.curl_->handle; });
+        Response current_response = *it;
+        responses.erase(it);
+        sorted_responses.push_back(current_response);
+    }
+
+    return sorted_responses;
 }
 
 std::vector<Response> MultiPerform::MakeRequest() {

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -4,7 +4,7 @@ namespace cpr {
 
 MultiPerform::MultiPerform() : multicurl_(new CurlMultiHolder()) {}
 
-void MultiPerform::AddSession(std::shared_ptr<Session> session) {
+void MultiPerform::AddSession(std::shared_ptr<Session>& session) {
     // Add easy handle to multi handle
     CURLMcode error_code = curl_multi_add_handle(multicurl_->handle, session->curl_->handle);
     if (error_code) {
@@ -16,7 +16,7 @@ void MultiPerform::AddSession(std::shared_ptr<Session> session) {
     sessions_.push_back(session);
 }
 
-void MultiPerform::RemoveSession(std::shared_ptr<Session> session) {
+void MultiPerform::RemoveSession(std::shared_ptr<Session>& session) {
     // Remove easy handle from multihandle
     CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, session->curl_->handle);
     if (error_code) {

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -8,7 +8,7 @@ void MultiPerform::AddSession(std::shared_ptr<Session>& session) {
     // Add easy handle to multi handle
     CURLMcode error_code = curl_multi_add_handle(multicurl_->handle, session->curl_->handle);
     if (error_code) {
-        fprintf(stderr, "curl_multi_add_handle() failed, code %d.\n", (int) error_code);
+        fprintf(stderr, "curl_multi_add_handle() failed, code %d.\n", static_cast<int>(error_code));
         return;
     }
 
@@ -20,7 +20,7 @@ void MultiPerform::RemoveSession(std::shared_ptr<Session>& session) {
     // Remove easy handle from multihandle
     CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, session->curl_->handle);
     if (error_code) {
-        fprintf(stderr, "curl_multi_remove_handle() failed, code %d.\n", (int) error_code);
+        fprintf(stderr, "curl_multi_remove_handle() failed, code %d.\n", static_cast<int>(error_code));
         return;
     }
 
@@ -40,14 +40,14 @@ void MultiPerform::DoMultiPerform() {
     do {
         error_code = curl_multi_perform(multicurl_->handle, &still_running);
         if (error_code) {
-            fprintf(stderr, "curl_multi_perform() failed, code %d.\n", (int) error_code);
+            fprintf(stderr, "curl_multi_perform() failed, code %d.\n", static_cast<int>(error_code));
             break;
         }
 
         if (still_running) {
             error_code = curl_multi_poll(multicurl_->handle, NULL, 0, 1000, NULL);
             if (error_code) {
-                fprintf(stderr, "curl_multi_poll() failed, code %d.\n", (int) error_code);
+                fprintf(stderr, "curl_multi_poll() failed, code %d.\n", static_cast<int>(error_code));
                 break;
             }
         }

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -46,7 +46,7 @@ void MultiPerform::DoMultiPerform() {
         }
 
         if (still_running) {
-            error_code = curl_multi_poll(multicurl_->handle, NULL, 0, 1000, NULL);
+            error_code = curl_multi_poll(multicurl_->handle, nullptr, 0, 1000, nullptr);
             if (error_code) {
                 fprintf(stderr, "curl_multi_poll() failed, code %d.\n", static_cast<int>(error_code));
                 break;

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -30,7 +30,7 @@ constexpr long OFF = 0L;
 
 CURLcode Session::DoEasyPerform() {
     if (isUsedInMultiPerform) {
-        fprintf(stderr, "curl_easy_perform cannot be executed if the CURL handle is used in a MultiPerform.\n");
+        (void) fprintf(stderr, "curl_easy_perform cannot be executed if the CURL handle is used in a MultiPerform.\n");
         return CURLcode::CURLE_FAILED_INIT;
     }
     return curl_easy_perform(curl_->handle);

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <fstream>
 #include <functional>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -30,7 +31,7 @@ constexpr long OFF = 0L;
 
 CURLcode Session::DoEasyPerform() {
     if (isUsedInMultiPerform) {
-        (void) fprintf(stderr, "curl_easy_perform cannot be executed if the CURL handle is used in a MultiPerform.\n");
+        std::cerr << "curl_easy_perform cannot be executed if the CURL handle is used in a MultiPerform." << std::endl;
         return CURLcode::CURLE_FAILED_INIT;
     }
     return curl_easy_perform(curl_->handle);

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -6,7 +6,6 @@ target_include_directories(cpr PUBLIC
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/cpr_generated_includes/>)
 
 target_sources(cpr PRIVATE
-
     # Header files (useful in IDEs)
     cpr/accept_encoding.h
     cpr/api.h
@@ -46,6 +45,7 @@ target_sources(cpr PRIVATE
     cpr/http_version.h
     cpr/interceptor.h
     cpr/filesystem.h
+    cpr/curlmultiholder.h
     ${PROJECT_BINARY_DIR}/cpr_generated_includes/cpr/cprver.h
 )
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(cpr PRIVATE
     cpr/interceptor.h
     cpr/filesystem.h
     cpr/curlmultiholder.h
+    cpr/multiperform.h
     ${PROJECT_BINARY_DIR}/cpr_generated_includes/cpr/cprver.h
 )
 

--- a/include/cpr/api.h
+++ b/include/cpr/api.h
@@ -300,6 +300,48 @@ std::vector<Response> MultiGet(Ts&&... ts) {
     return multiperform.Get();
 }
 
+template <typename... Ts>
+std::vector<Response> MultiDelete(Ts&&... ts) {
+    MultiPerform multiperform;
+    priv::setup_multiperform<Ts...>(multiperform, std::forward<Ts>(ts)...);
+    return multiperform.Delete();
+}
+
+template <typename... Ts>
+std::vector<Response> MultiPut(Ts&&... ts) {
+    MultiPerform multiperform;
+    priv::setup_multiperform<Ts...>(multiperform, std::forward<Ts>(ts)...);
+    return multiperform.Put();
+}
+
+template <typename... Ts>
+std::vector<Response> MultiHead(Ts&&... ts) {
+    MultiPerform multiperform;
+    priv::setup_multiperform<Ts...>(multiperform, std::forward<Ts>(ts)...);
+    return multiperform.Head();
+}
+
+template <typename... Ts>
+std::vector<Response> MultiOptions(Ts&&... ts) {
+    MultiPerform multiperform;
+    priv::setup_multiperform<Ts...>(multiperform, std::forward<Ts>(ts)...);
+    return multiperform.Options();
+}
+
+template <typename... Ts>
+std::vector<Response> MultiPatch(Ts&&... ts) {
+    MultiPerform multiperform;
+    priv::setup_multiperform<Ts...>(multiperform, std::forward<Ts>(ts)...);
+    return multiperform.Patch();
+}
+
+template <typename... Ts>
+std::vector<Response> MultiPost(Ts&&... ts) {
+    MultiPerform multiperform;
+    priv::setup_multiperform<Ts...>(multiperform, std::forward<Ts>(ts)...);
+    return multiperform.Post();
+}
+
 } // namespace cpr
 
 #endif

--- a/include/cpr/api.h
+++ b/include/cpr/api.h
@@ -52,46 +52,16 @@ void set_option(Session& session, Ts&&... ts) {
     set_option_internal<false, Ts...>(session, std::forward<Ts>(ts)...);
 }
 
-// This can be removed once the c++ standard has been updated
-// Source: https://gist.github.com/ntessore/dc17769676fb3c6daa1f#file-integer_sequence-hpp
-namespace std14 {
-
-template <typename T, T... Ints>
-struct integer_sequence {
-    typedef T value_type;
-    static constexpr std::size_t size() {
-        return sizeof...(Ints);
-    }
-};
-
-template <std::size_t... Ints>
-using index_sequence = integer_sequence<std::size_t, Ints...>;
-
-template <typename T, std::size_t N, T... Is>
-struct make_integer_sequence : make_integer_sequence<T, N - 1, N - 1, Is...> {};
-
-template <typename T, T... Is>
-struct make_integer_sequence<T, 0, Is...> : integer_sequence<T, Is...> {};
-
-template <std::size_t N>
-using make_index_sequence = make_integer_sequence<std::size_t, N>;
-
-// https://en.cppreference.com/w/cpp/types/decay
-template <class T>
-using decay_t = typename std::decay<T>::type;
-
-} // namespace std14
-
 // Idea: https://stackoverflow.com/a/19060157
 template <typename Tuple, std::size_t... I>
-void apply_set_option_internal(Session& session, Tuple&& t, std14::index_sequence<I...>) {
+void apply_set_option_internal(Session& session, Tuple&& t, std::index_sequence<I...>) {
     set_option(session, std::get<I>(std::forward<Tuple>(t))...);
 }
 
 // Idea: https://stackoverflow.com/a/19060157
 template <typename Tuple>
 void apply_set_option(Session& session, Tuple&& t) {
-    using Indices = std14::make_index_sequence<std::tuple_size<std14::decay_t<Tuple>>::value>;
+    using Indices = std::make_index_sequence<std::tuple_size<std::decay_t<Tuple>>::value>;
     apply_set_option_internal(session, std::forward<Tuple>(t), Indices());
 }
 

--- a/include/cpr/cpr.h
+++ b/include/cpr/cpr.h
@@ -21,6 +21,7 @@
 #include "cpr/local_port_range.h"
 #include "cpr/low_speed.h"
 #include "cpr/multipart.h"
+#include "cpr/multiperform.h"
 #include "cpr/parameters.h"
 #include "cpr/payload.h"
 #include "cpr/proxies.h"

--- a/include/cpr/curlmultiholder.h
+++ b/include/cpr/curlmultiholder.h
@@ -1,0 +1,18 @@
+#ifndef CPR_CURLMULTIHOLDER_H
+#define CPR_CURLMULTIHOLDER_H
+
+#include <curl/curl.h>
+
+namespace cpr {
+
+class CurlMultiHolder {
+  public:
+    CurlMultiHolder();
+    ~CurlMultiHolder();
+
+    CURLM* handle{nullptr};
+};
+
+} // namespace cpr
+
+#endif

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -15,7 +15,7 @@ class MultiPerform {
     MultiPerform();
     std::vector<Response> Get();
     void AddSession(std::shared_ptr<Session>& session);
-    void RemoveSession(std::shared_ptr<Session>& session);
+    void RemoveSession(const std::shared_ptr<Session>& session);
 
   private:
     void PrepareGet();

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -14,8 +14,8 @@ class MultiPerform {
   public:
     MultiPerform();
     std::vector<Response> Get();
-    void AddSession(std::shared_ptr<Session> session);
-    void RemoveSession(std::shared_ptr<Session> session);
+    void AddSession(std::shared_ptr<Session>& session);
+    void RemoveSession(std::shared_ptr<Session>& session);
 
   private:
     void PrepareGet();

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -1,0 +1,31 @@
+#ifndef CPR_MULTIPERFORM_H
+#define CPR_MULTIPERFORM_H
+
+#include <memory>
+#include <vector>
+
+#include "cpr/curlmultiholder.h"
+#include "cpr/response.h"
+#include "cpr/session.h"
+
+namespace cpr {
+
+class MultiPerform {
+  public:
+    MultiPerform();
+    std::vector<Response> Get();
+    void AddSession(std::shared_ptr<Session> session);
+    void RemoveSession(std::shared_ptr<Session> session);
+
+  private:
+    void PrepareGet();
+    std::vector<Response> MakeRequest();
+    void DoMultiPerform();
+    std::vector<Response> ReadMultiInfo();
+
+    std::vector<std::shared_ptr<Session>> sessions_;
+    std::unique_ptr<CurlMultiHolder> multicurl_;
+};
+} // namespace cpr
+
+#endif

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 #include "cpr/curlmultiholder.h"
@@ -95,12 +96,18 @@ void MultiPerform::PrepareDownload(DownloadArgTypes... args) {
 
 template <typename... DownloadArgTypes>
 std::vector<Response> MultiPerform::Download(DownloadArgTypes... args) {
+    if (sizeof...(args) != sessions_.size()) {
+        throw std::invalid_argument("Number of download arguments has to match the number of sessions added to the multiperform!");
+    }
     PrepareDownload(args...);
     return MakeDownloadRequest();
 }
 
 template <typename... DownloadArgTypes>
 std::vector<Response> MultiPerform::PerformDownload(DownloadArgTypes... args) {
+    if (sizeof...(args) != sessions_.size()) {
+        throw std::invalid_argument("Number of download arguments has to match the number of sessions added to the multiperform!");
+    }
     PrepareDownloadSessions<DownloadArgTypes...>(0, args...);
     return MakeDownloadRequest();
 }

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -49,6 +49,10 @@ class MultiPerform {
     void PrepareSessions();
     template <typename CurrentDownloadArgType, typename... DownloadArgTypes>
     void PrepareDownloadSessions(size_t sessions_index, CurrentDownloadArgType current_arg, DownloadArgTypes... args);
+    template <typename CurrentDownloadArgType>
+    void PrepareDownloadSessions(size_t sessions_index, CurrentDownloadArgType current_arg);
+    void PrepareDownloadSession(size_t sessions_index, std::ofstream& file);
+    void PrepareDownloadSession(size_t sessions_index, const WriteCallback& write);
 
     void PrepareGet();
     void PrepareDelete();
@@ -71,22 +75,14 @@ class MultiPerform {
     bool is_download_multi_perform{false};
 };
 
+template <typename CurrentDownloadArgType>
+void MultiPerform::PrepareDownloadSessions(size_t sessions_index, CurrentDownloadArgType current_arg) {
+    PrepareDownloadSession(sessions_index, current_arg);
+}
+
 template <typename CurrentDownloadArgType, typename... DownloadArgTypes>
 void MultiPerform::PrepareDownloadSessions(size_t sessions_index, CurrentDownloadArgType current_arg, DownloadArgTypes... args) {
-    if (sessions_index >= sessions_.size()) {
-        return;
-    }
-
-    std::pair<std::shared_ptr<Session>, HttpMethod>& pair = sessions_[sessions_index];
-    switch (pair.second) {
-        case HttpMethod::DOWNLOAD_REQUEST:
-            pair.first->PrepareDownload(current_arg);
-            break;
-        default:
-            fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!\n");
-            return;
-    }
-
+    PrepareDownloadSession(sessions_index, current_arg);
     PrepareDownloadSessions<DownloadArgTypes...>(sessions_index + 1, args...);
 }
 

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -1,6 +1,7 @@
 #ifndef CPR_MULTIPERFORM_H
 #define CPR_MULTIPERFORM_H
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -14,14 +15,32 @@ class MultiPerform {
   public:
     MultiPerform();
     std::vector<Response> Get();
+    std::vector<Response> Delete();
+    std::vector<Response> Download(const WriteCallback& write);
+    std::vector<Response> Download(std::ofstream& file);
+    std::vector<Response> Put();
+    std::vector<Response> Head();
+    std::vector<Response> Options();
+    std::vector<Response> Patch();
+    std::vector<Response> Post();
     void AddSession(std::shared_ptr<Session>& session);
     void RemoveSession(const std::shared_ptr<Session>& session);
 
   private:
+    void PrepareSessions(std::function<void(Session&)> setup_function);
     void PrepareGet();
+    void PrepareDelete();
+    void PrepareDownload(const WriteCallback& write);
+    void PrepareDownload(std::ofstream& file);
+    void PreparePut();
+    void PreparePatch();
+    void PrepareHead();
+    void PrepareOptions();
+    void PreparePost();
     std::vector<Response> MakeRequest();
+    std::vector<Response> MakeDownloadRequest();
     void DoMultiPerform();
-    std::vector<Response> ReadMultiInfo();
+    std::vector<Response> ReadMultiInfo(std::function<Response(Session&, CURLcode)> complete_function);
 
     std::vector<std::shared_ptr<Session>> sessions_;
     std::unique_ptr<CurlMultiHolder> multicurl_;

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -27,6 +27,8 @@ class MultiPerform {
     };
 
     MultiPerform();
+    ~MultiPerform();
+
     std::vector<Response> Get();
     std::vector<Response> Delete();
     template <typename... DownloadArgTypes>

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -13,38 +13,102 @@ namespace cpr {
 
 class MultiPerform {
   public:
+    enum class HttpMethod {
+        UNDEFINED = 0,
+        GET_REQUEST,
+        POST_REQUEST,
+        PUT_REQUEST,
+        DELETE_REQUEST,
+        PATCH_REQUEST,
+        HEAD_REQUEST,
+        OPTIONS_REQUEST,
+        DOWNLOAD_REQUEST,
+    };
+
     MultiPerform();
     std::vector<Response> Get();
     std::vector<Response> Delete();
-    std::vector<Response> Download(const WriteCallback& write);
-    std::vector<Response> Download(std::ofstream& file);
+    template <typename... DownloadArgTypes>
+    std::vector<Response> Download(DownloadArgTypes... args);
     std::vector<Response> Put();
     std::vector<Response> Head();
     std::vector<Response> Options();
     std::vector<Response> Patch();
     std::vector<Response> Post();
-    void AddSession(std::shared_ptr<Session>& session);
+
+    std::vector<Response> Perform();
+    template <typename... DownloadArgTypes>
+    std::vector<Response> PerformDownload(DownloadArgTypes... args);
+
+    void AddSession(std::shared_ptr<Session>& session, HttpMethod method = HttpMethod::UNDEFINED);
     void RemoveSession(const std::shared_ptr<Session>& session);
 
   private:
-    void PrepareSessions(std::function<void(Session&)> setup_function);
+    void SetHttpMethod(HttpMethod method);
+
+    void PrepareSessions();
+    template <typename CurrentDownloadArgType, typename... DownloadArgTypes>
+    void PrepareDownloadSessions(size_t sessions_index, CurrentDownloadArgType current_arg, DownloadArgTypes... args);
+
     void PrepareGet();
     void PrepareDelete();
-    void PrepareDownload(const WriteCallback& write);
-    void PrepareDownload(std::ofstream& file);
     void PreparePut();
     void PreparePatch();
     void PrepareHead();
     void PrepareOptions();
     void PreparePost();
+    template <typename... DownloadArgTypes>
+    void PrepareDownload(DownloadArgTypes... args);
+
     std::vector<Response> MakeRequest();
     std::vector<Response> MakeDownloadRequest();
-    void DoMultiPerform();
-    std::vector<Response> ReadMultiInfo(std::function<Response(Session&, CURLcode)> complete_function);
 
-    std::vector<std::shared_ptr<Session>> sessions_;
+    void DoMultiPerform();
+    std::vector<Response> ReadMultiInfo(std::function<Response(Session&, CURLcode)>&& complete_function);
+
+    std::vector<std::pair<std::shared_ptr<Session>, HttpMethod>> sessions_;
     std::unique_ptr<CurlMultiHolder> multicurl_;
+    bool is_download_multi_perform{false};
 };
+
+template <typename CurrentDownloadArgType, typename... DownloadArgTypes>
+void MultiPerform::PrepareDownloadSessions(size_t sessions_index, CurrentDownloadArgType current_arg, DownloadArgTypes... args) {
+    if (sessions_index >= sessions_.size()) {
+        return;
+    }
+
+    std::pair<std::shared_ptr<Session>, HttpMethod>& pair = sessions_[sessions_index];
+    switch (pair.second) {
+        case HttpMethod::DOWNLOAD_REQUEST:
+            pair.first->PrepareDownload(current_arg);
+            break;
+        default:
+            fprintf(stderr, "PrepareSessions failed: Undefined HttpMethod or non download method with arguments!\n");
+            return;
+    }
+
+    PrepareDownloadSessions<DownloadArgTypes...>(sessions_index + 1, args...);
+}
+
+
+template <typename... DownloadArgTypes>
+void MultiPerform::PrepareDownload(DownloadArgTypes... args) {
+    SetHttpMethod(HttpMethod::DOWNLOAD_REQUEST);
+    PrepareDownloadSessions<DownloadArgTypes...>(0, args...);
+}
+
+template <typename... DownloadArgTypes>
+std::vector<Response> MultiPerform::Download(DownloadArgTypes... args) {
+    PrepareDownload(args...);
+    return MakeDownloadRequest();
+}
+
+template <typename... DownloadArgTypes>
+std::vector<Response> MultiPerform::PerformDownload(DownloadArgTypes... args) {
+    PrepareDownloadSessions<DownloadArgTypes...>(0, args...);
+    return MakeDownloadRequest();
+}
+
 } // namespace cpr
 
 #endif

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -17,8 +17,11 @@
 
 namespace cpr {
 
+class MultiPerform;
+
 class Response {
   private:
+    friend MultiPerform;
     std::shared_ptr<CurlHolder> curl_{nullptr};
 
   public:

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -205,7 +205,10 @@ class Session : public std::enable_shared_from_this<Session> {
     void PreparePatch();
     void PreparePost();
     void PreparePut();
+    void PrepareDownload(const WriteCallback& write);
+    void PrepareDownload(std::ofstream& file);
     Response Complete(CURLcode curl_error);
+    Response CompleteDownload(CURLcode curl_error);
 
     void AddInterceptor(const std::shared_ptr<Interceptor>& pinterceptor);
 
@@ -242,6 +245,7 @@ class Session : public std::enable_shared_from_this<Session> {
     Response makeRequest();
     Response proceed();
     void prepareCommon();
+    void prepareCommonDownload();
     void SetHeaderInternal();
     std::shared_ptr<Session> GetSharedPtrFromThis();
     CURLcode DoEasyPerform();

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -236,6 +236,7 @@ class Session : public std::enable_shared_from_this<Session> {
     std::string response_string_;
     std::string header_string_;
     std::queue<std::shared_ptr<Interceptor>> interceptors_;
+    bool isUsedInMultiPerform{false};
 
     Response makeDownloadRequest();
     Response makeRequest();
@@ -243,6 +244,7 @@ class Session : public std::enable_shared_from_this<Session> {
     void prepareCommon();
     void SetHeaderInternal();
     std::shared_ptr<Session> GetSharedPtrFromThis();
+    CURLcode DoEasyPerform();
 };
 
 template <typename Then>

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -42,6 +42,7 @@ namespace cpr {
 using AsyncResponse = std::future<Response>;
 
 class Interceptor;
+class MultiPerform;
 
 class Session : public std::enable_shared_from_this<Session> {
   public:
@@ -211,6 +212,7 @@ class Session : public std::enable_shared_from_this<Session> {
   private:
     // Interceptors should be able to call the private procceed() function
     friend Interceptor;
+    friend MultiPerform;
 
     bool hasBodyOrPayload_{false};
     bool chunkedTransferEncoding_{false};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ add_cpr_test(proxy_auth)
 add_cpr_test(version)
 add_cpr_test(download)
 add_cpr_test(interceptor)
+add_cpr_test(multiperform)
 
 if (ENABLE_SSL_TESTS)
     add_cpr_test(ssl)

--- a/test/multiperform_tests.cpp
+++ b/test/multiperform_tests.cpp
@@ -13,7 +13,7 @@ using namespace cpr;
 
 static HttpServer* server = new HttpServer();
 
-TEST(MultiperformTests, MultiperformSingleSessionGetTest) {
+TEST(MultiperformGetTests, MultiperformSingleSessionGetTest) {
     Url url{server->GetBaseUrl() + "/hello.html"};
     std::shared_ptr<Session> session = std::make_shared<Session>();
     session->SetUrl(url);
@@ -30,7 +30,7 @@ TEST(MultiperformTests, MultiperformSingleSessionGetTest) {
     EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
 }
 
-TEST(MultiperformTests, MultiperformTwoSessionsGetTest) {
+TEST(MultiperformGetTests, MultiperformTwoSessionsGetTest) {
     MultiPerform multiperform;
     std::vector<Url> urls;
     urls.push_back({server->GetBaseUrl() + "/hello.html"});
@@ -70,7 +70,7 @@ TEST(MultiperformTests, MultiperformTwoSessionsGetTest) {
     }
 }
 
-TEST(MultiperformTests, MultiperformRemoveSessionGetTest) {
+TEST(MultiperformGetTests, MultiperformRemoveSessionGetTest) {
     MultiPerform multiperform;
     std::vector<Url> urls;
     urls.push_back({server->GetBaseUrl() + "/hello.html"});
@@ -98,7 +98,7 @@ TEST(MultiperformTests, MultiperformRemoveSessionGetTest) {
     EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
 }
 
-TEST(MultiperformTests, MultiperformTenSessionsGetTest) {
+TEST(MultiperformGetTests, MultiperformTenSessionsGetTest) {
     MultiPerform multiperform;
     std::vector<Url> urls;
     std::vector<std::shared_ptr<Session>> sessions;
@@ -122,7 +122,7 @@ TEST(MultiperformTests, MultiperformTenSessionsGetTest) {
     }
 }
 
-TEST(MultiperformTests, MultiperformApiSingleGetTest) {
+TEST(MultiperformGetTests, MultiperformApiSingleGetTest) {
     std::vector<Response> responses = MultiGet(std::tuple<Url>{Url{server->GetBaseUrl() + "/hello.html"}});
     EXPECT_EQ(responses.size(), 1);
     std::string expected_text{"Hello world!"};
@@ -133,7 +133,7 @@ TEST(MultiperformTests, MultiperformApiSingleGetTest) {
     EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
 }
 
-TEST(MultiperformTests, MultiperformApiTwoGetsTest) {
+TEST(MultiperformGetTests, MultiperformApiTwoGetsTest) {
     std::vector<Response> responses = MultiGet(std::tuple<Url, Timeout>{Url{server->GetBaseUrl() + "/low_speed_timeout.html"}, Timeout{1000}}, std::tuple<Url>{Url{server->GetBaseUrl() + "/error.html"}});
 
     EXPECT_EQ(responses.size(), 2);

--- a/test/multiperform_tests.cpp
+++ b/test/multiperform_tests.cpp
@@ -13,6 +13,105 @@ using namespace cpr;
 
 static HttpServer* server = new HttpServer();
 
+bool write_data(std::string /*data*/, intptr_t /*userdata*/) {
+    return true;
+}
+
+TEST(MultiperformAddSessionTests, MultiperformAddSingleSessionTest) {
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+
+    EXPECT_EQ(2, session.use_count());
+}
+
+TEST(MultiperformAddSessionTests, MultiperformAddMultipleSessionsTest) {
+    std::vector<std::shared_ptr<Session>> sessions;
+    for (int i = 0; i < 10; ++i) {
+        sessions.push_back(std::make_shared<Session>());
+    }
+
+    MultiPerform multiperform;
+    for (std::shared_ptr<Session>& session : sessions) {
+        multiperform.AddSession(session);
+        EXPECT_EQ(2, session.use_count());
+    }
+}
+
+TEST(MultiperformAddSessionTests, MultiperformAddMultipleNonDownloadSessionsTest) {
+    std::vector<std::shared_ptr<Session>> sessions;
+    for (int i = 0; i < 10; ++i) {
+        sessions.push_back(std::make_shared<Session>());
+    }
+
+    MultiPerform multiperform;
+    for (std::shared_ptr<Session>& session : sessions) {
+        multiperform.AddSession(session, MultiPerform::HttpMethod::GET_REQUEST);
+        EXPECT_EQ(2, session.use_count());
+    }
+}
+
+TEST(MultiperformAddSessionTests, MultiperformAddMultipleDownloadSessionsTest) {
+    std::vector<std::shared_ptr<Session>> sessions;
+    for (int i = 0; i < 10; ++i) {
+        sessions.push_back(std::make_shared<Session>());
+    }
+
+    MultiPerform multiperform;
+    for (std::shared_ptr<Session>& session : sessions) {
+        multiperform.AddSession(session, MultiPerform::HttpMethod::DOWNLOAD_REQUEST);
+        EXPECT_EQ(2, session.use_count());
+    }
+}
+
+TEST(MultiperformAddSessionTests, MultiperformAddTwoMixedTypeSessionsTest) {
+    std::shared_ptr<Session> session_1 = std::make_shared<Session>();
+    std::shared_ptr<Session> session_2 = std::make_shared<Session>();
+    MultiPerform multiperform;
+    multiperform.AddSession(session_1, MultiPerform::HttpMethod::GET_REQUEST);
+    EXPECT_EQ(2, session_1.use_count());
+    EXPECT_THROW(multiperform.AddSession(session_2, MultiPerform::HttpMethod::DOWNLOAD_REQUEST), std::invalid_argument);
+}
+
+TEST(MultiperformAddSessionTests, MultiperformAddTwoMixedTypeSessionsReversTest) {
+    std::shared_ptr<Session> session_1 = std::make_shared<Session>();
+    std::shared_ptr<Session> session_2 = std::make_shared<Session>();
+    MultiPerform multiperform;
+    multiperform.AddSession(session_1, MultiPerform::HttpMethod::DOWNLOAD_REQUEST);
+    EXPECT_EQ(2, session_1.use_count());
+    EXPECT_THROW(multiperform.AddSession(session_2, MultiPerform::HttpMethod::GET_REQUEST), std::invalid_argument);
+}
+
+TEST(MultiperformRemoveSessionTests, MultiperformRemoveSingleSessionTest) {
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    EXPECT_EQ(2, session.use_count());
+    multiperform.RemoveSession(session);
+    EXPECT_EQ(1, session.use_count());
+}
+
+TEST(MultiperformRemoveSessionTests, MultiperformRemoveMultipleSessionsTest) {
+    std::vector<std::shared_ptr<Session>> sessions;
+    for (int i = 0; i < 10; ++i) {
+        sessions.push_back(std::make_shared<Session>());
+    }
+
+    MultiPerform multiperform;
+    for (std::shared_ptr<Session>& session : sessions) {
+        multiperform.AddSession(session);
+        EXPECT_EQ(2, session.use_count());
+        multiperform.RemoveSession(session);
+        EXPECT_EQ(1, session.use_count());
+    }
+}
+
+TEST(MultiperformRemoveSessionTests, MultiperformRemoveNonExistingSessionTest) {
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    MultiPerform multiperform;
+    EXPECT_THROW(multiperform.RemoveSession(session), std::invalid_argument);
+}
+
 TEST(MultiperformGetTests, MultiperformSingleSessionGetTest) {
     Url url{server->GetBaseUrl() + "/hello.html"};
     std::shared_ptr<Session> session = std::make_shared<Session>();
@@ -122,7 +221,340 @@ TEST(MultiperformGetTests, MultiperformTenSessionsGetTest) {
     }
 }
 
-TEST(MultiperformGetTests, MultiperformApiSingleGetTest) {
+TEST(MultiperformDeleteTests, MultiperformSingleSessionDeleteTest) {
+    Url url{server->GetBaseUrl() + "/delete.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    std::vector<Response> responses = multiperform.Delete();
+
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{"Delete success"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformDownloadTests, MultiperformSingleSessionDownloadTest) {
+    Url url{server->GetBaseUrl() + "/download_gzip.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    session->SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    std::vector<Response> responses = multiperform.Download(WriteCallback{write_data, 0});
+
+    EXPECT_EQ(responses.size(), 1);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformDownloadTests, MultiperformSingleSessionDownloadNonMatchingArgumentsNumberTest) {
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    EXPECT_THROW(std::vector<Response> responses = multiperform.Download(WriteCallback{write_data, 0}, WriteCallback{write_data, 0}), std::invalid_argument);
+}
+
+TEST(MultiperformDownloadTests, MultiperformTwoSessionsDownloadTest) {
+    MultiPerform multiperform;
+    std::vector<Url> urls;
+    urls.push_back({server->GetBaseUrl() + "/download_gzip.html"});
+    urls.push_back({server->GetBaseUrl() + "/download_gzip.html"});
+
+    std::vector<std::shared_ptr<Session>> sessions;
+    sessions.push_back(std::make_shared<Session>());
+    sessions.push_back(std::make_shared<Session>());
+
+
+    for (size_t i = 0; i < sessions.size(); ++i) {
+        sessions.at(i)->SetUrl(urls.at(i));
+        sessions.at(i)->SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+
+        multiperform.AddSession(sessions.at(i));
+    }
+
+    std::vector<Response> responses = multiperform.Download(WriteCallback{write_data, 0}, WriteCallback{write_data, 0});
+
+    EXPECT_EQ(responses.size(), sessions.size());
+    for (size_t i = 0; i < responses.size(); ++i) {
+        EXPECT_EQ(urls.at(i), responses.at(i).url);
+        EXPECT_EQ(200, responses.at(i).status_code);
+        EXPECT_EQ(ErrorCode::OK, responses.at(i).error.code);
+    }
+}
+
+TEST(MultiperformPutTests, MultiperformSingleSessionPutTest) {
+    Url url{server->GetBaseUrl() + "/put.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    session->SetPayload(Payload{{"x", "5"}});
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    std::vector<Response> responses = multiperform.Put();
+
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{
+            "{\n"
+            "  \"x\": 5\n"
+            "}"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(std::string{"application/json"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformHeadTests, MultiperformSingleSessionHeadTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    std::vector<Response> responses = multiperform.Head();
+
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{""};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformOptionsTests, MultiperformSingleSessionOptionsTest) {
+    Url url{server->GetBaseUrl() + "/"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    std::vector<Response> responses = multiperform.Options();
+
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{""};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"}, responses.at(0).header["Access-Control-Allow-Methods"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformPatchTests, MultiperformSingleSessionPatchTest) {
+    Url url{server->GetBaseUrl() + "/patch.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    session->SetPayload(Payload{{"x", "5"}});
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    std::vector<Response> responses = multiperform.Patch();
+
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{
+            "{\n"
+            "  \"x\": 5\n"
+            "}"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(std::string{"application/json"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformPostTests, MultiperformSingleSessionPostTest) {
+    Url url{server->GetBaseUrl() + "/url_post.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    session->SetPayload(Payload{{"x", "5"}});
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    std::vector<Response> responses = multiperform.Post();
+
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{
+            "{\n"
+            "  \"x\": 5\n"
+            "}"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(std::string{"application/json"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(201, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformPerformTests, MultiperformSingleGetPerformTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multiperform;
+    multiperform.AddSession(session, MultiPerform::HttpMethod::GET_REQUEST);
+    std::vector<Response> responses = multiperform.Perform();
+
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{"Hello world!"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformPerformTests, MultiperformTwoGetPerformTest) {
+    MultiPerform multiperform;
+    std::vector<Url> urls;
+    urls.push_back({server->GetBaseUrl() + "/hello.html"});
+    urls.push_back({server->GetBaseUrl() + "/error.html"});
+
+    std::vector<std::shared_ptr<Session>> sessions;
+    sessions.push_back(std::make_shared<Session>());
+    sessions.push_back(std::make_shared<Session>());
+
+
+    for (size_t i = 0; i < sessions.size(); ++i) {
+        sessions.at(i)->SetUrl(urls.at(i));
+        multiperform.AddSession(sessions.at(i), MultiPerform::HttpMethod::GET_REQUEST);
+    }
+
+    std::vector<Response> responses = multiperform.Perform();
+
+    EXPECT_EQ(responses.size(), sessions.size());
+    std::vector<std::string> expected_texts;
+    expected_texts.push_back("Hello world!");
+    expected_texts.push_back("Not Found");
+
+    std::vector<std::string> expected_content_types;
+    expected_content_types.push_back("text/html");
+    expected_content_types.push_back("text/plain");
+
+    std::vector<long> expected_status_codes;
+    expected_status_codes.push_back(200);
+    expected_status_codes.push_back(404);
+
+    for (size_t i = 0; i < responses.size(); ++i) {
+        EXPECT_EQ(expected_texts.at(i), responses.at(i).text);
+        EXPECT_EQ(urls.at(i), responses.at(i).url);
+        EXPECT_EQ(expected_content_types.at(i), responses.at(i).header["content-type"]);
+        EXPECT_EQ(expected_status_codes.at(i), responses.at(i).status_code);
+        EXPECT_EQ(ErrorCode::OK, responses.at(i).error.code);
+    }
+}
+
+TEST(MultiperformPerformTests, MultiperformMixedMethodsPerformTest) {
+    MultiPerform multiperform;
+    std::vector<Url> urls;
+    urls.push_back({server->GetBaseUrl() + "/hello.html"});
+    urls.push_back({server->GetBaseUrl() + "/delete.html"});
+    urls.push_back({server->GetBaseUrl() + "/error.html"});
+    urls.push_back({server->GetBaseUrl() + "/url_post.html"});
+
+    std::vector<std::shared_ptr<Session>> sessions;
+    sessions.push_back(std::make_shared<Session>());
+    sessions.push_back(std::make_shared<Session>());
+    sessions.push_back(std::make_shared<Session>());
+    sessions.push_back(std::make_shared<Session>());
+
+    std::vector<MultiPerform::HttpMethod> methods;
+    methods.push_back(MultiPerform::HttpMethod::GET_REQUEST);
+    methods.push_back(MultiPerform::HttpMethod::DELETE_REQUEST);
+    methods.push_back(MultiPerform::HttpMethod::GET_REQUEST);
+    methods.push_back(MultiPerform::HttpMethod::POST_REQUEST);
+
+    for (size_t i = 0; i < sessions.size(); ++i) {
+        sessions.at(i)->SetUrl(urls.at(i));
+        if (methods.at(i) == MultiPerform::HttpMethod::POST_REQUEST) {
+            sessions.at(i)->SetPayload(Payload{{"x", "5"}});
+        }
+        multiperform.AddSession(sessions.at(i), methods.at(i));
+    }
+
+    std::vector<Response> responses = multiperform.Perform();
+
+    EXPECT_EQ(responses.size(), sessions.size());
+
+    std::vector<std::string> expected_texts;
+    expected_texts.push_back("Hello world!");
+    expected_texts.push_back("Delete success");
+    expected_texts.push_back("Not Found");
+    expected_texts.push_back(
+            {"{\n"
+             "  \"x\": 5\n"
+             "}"});
+
+    std::vector<std::string> expected_content_types;
+    expected_content_types.push_back("text/html");
+    expected_content_types.push_back("text/html");
+    expected_content_types.push_back("text/plain");
+    expected_content_types.push_back("application/json");
+
+    std::vector<long> expected_status_codes;
+    expected_status_codes.push_back(200);
+    expected_status_codes.push_back(200);
+    expected_status_codes.push_back(404);
+    expected_status_codes.push_back(201);
+
+    for (size_t i = 0; i < responses.size(); ++i) {
+        EXPECT_EQ(expected_texts.at(i), responses.at(i).text);
+        EXPECT_EQ(urls.at(i), responses.at(i).url);
+        EXPECT_EQ(expected_content_types.at(i), responses.at(i).header["content-type"]);
+        EXPECT_EQ(expected_status_codes.at(i), responses.at(i).status_code);
+        EXPECT_EQ(ErrorCode::OK, responses.at(i).error.code);
+    }
+}
+
+TEST(MultiperformPerformDownloadTests, MultiperformSinglePerformDownloadTest) {
+    Url url{server->GetBaseUrl() + "/download_gzip.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    session->SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+    MultiPerform multiperform;
+    multiperform.AddSession(session, MultiPerform::HttpMethod::DOWNLOAD_REQUEST);
+    std::vector<Response> responses = multiperform.PerformDownload(WriteCallback{write_data, 0});
+
+    EXPECT_EQ(responses.size(), 1);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformDownloadTests, MultiperformSinglePerformDownloadNonMatchingArgumentsNumberTest) {
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    MultiPerform multiperform;
+    multiperform.AddSession(session, MultiPerform::HttpMethod::DOWNLOAD_REQUEST);
+    EXPECT_THROW(std::vector<Response> responses = multiperform.PerformDownload(WriteCallback{write_data, 0}, WriteCallback{write_data, 0}), std::invalid_argument);
+}
+
+TEST(MultiperformPerformDownloadTests, MultiperformTwoPerformDownloadTest) {
+    MultiPerform multiperform;
+    std::vector<Url> urls;
+    urls.push_back({server->GetBaseUrl() + "/download_gzip.html"});
+    urls.push_back({server->GetBaseUrl() + "/download_gzip.html"});
+
+    std::vector<std::shared_ptr<Session>> sessions;
+    sessions.push_back(std::make_shared<Session>());
+    sessions.push_back(std::make_shared<Session>());
+
+
+    for (size_t i = 0; i < sessions.size(); ++i) {
+        sessions.at(i)->SetUrl(urls.at(i));
+        sessions.at(i)->SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+
+        multiperform.AddSession(sessions.at(i), MultiPerform::HttpMethod::DOWNLOAD_REQUEST);
+    }
+
+    std::vector<Response> responses = multiperform.PerformDownload(WriteCallback{write_data, 0}, WriteCallback{write_data, 0});
+
+    EXPECT_EQ(responses.size(), sessions.size());
+    for (size_t i = 0; i < responses.size(); ++i) {
+        EXPECT_EQ(urls.at(i), responses.at(i).url);
+        EXPECT_EQ(200, responses.at(i).status_code);
+        EXPECT_EQ(ErrorCode::OK, responses.at(i).error.code);
+    }
+}
+
+TEST(MultiperformAPITests, MultiperformApiSingleGetTest) {
     std::vector<Response> responses = MultiGet(std::tuple<Url>{Url{server->GetBaseUrl() + "/hello.html"}});
     EXPECT_EQ(responses.size(), 1);
     std::string expected_text{"Hello world!"};
@@ -133,7 +565,7 @@ TEST(MultiperformGetTests, MultiperformApiSingleGetTest) {
     EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
 }
 
-TEST(MultiperformGetTests, MultiperformApiTwoGetsTest) {
+TEST(MultiperformAPITests, MultiperformApiTwoGetsTest) {
     std::vector<Response> responses = MultiGet(std::tuple<Url, Timeout>{Url{server->GetBaseUrl() + "/low_speed_timeout.html"}, Timeout{1000}}, std::tuple<Url>{Url{server->GetBaseUrl() + "/error.html"}});
 
     EXPECT_EQ(responses.size(), 2);
@@ -164,6 +596,81 @@ TEST(MultiperformGetTests, MultiperformApiTwoGetsTest) {
         EXPECT_EQ(expected_status_codes.at(i), responses.at(i).status_code);
         EXPECT_EQ(expected_error_codes.at(i), responses.at(i).error.code);
     }
+}
+
+TEST(MultiperformAPITests, MultiperformApiSingleDeleteTest) {
+    std::vector<Response> responses = MultiDelete(std::tuple<Url>{Url{server->GetBaseUrl() + "/delete.html"}});
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{"Delete success"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(Url{server->GetBaseUrl() + "/delete.html"}, responses.at(0).url);
+    EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformAPITests, MultiperformApiSinglePutTest) {
+    std::vector<Response> responses = MultiPut(std::tuple<Url, Payload>{Url{server->GetBaseUrl() + "/put.html"}, Payload{{"x", "5"}}});
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{
+            "{\n"
+            "  \"x\": 5\n"
+            "}"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(Url{server->GetBaseUrl() + "/put.html"}, responses.at(0).url);
+    EXPECT_EQ(std::string{"application/json"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformAPITests, MultiperformApiSingleHeadTest) {
+    std::vector<Response> responses = MultiHead(std::tuple<Url>{Url{server->GetBaseUrl() + "/hello.html"}});
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{""};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(Url{server->GetBaseUrl() + "/hello.html"}, responses.at(0).url);
+    EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformAPITests, MultiperformApiSingleOptionsTest) {
+    std::vector<Response> responses = MultiOptions(std::tuple<Url>{Url{server->GetBaseUrl() + "/"}});
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{""};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(Url{server->GetBaseUrl() + "/"}, responses.at(0).url);
+    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"}, responses.at(0).header["Access-Control-Allow-Methods"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformAPITests, MultiperformApiSinglePatchTest) {
+    std::vector<Response> responses = MultiPatch(std::tuple<Url, Payload>{Url{server->GetBaseUrl() + "/patch.html"}, Payload{{"x", "5"}}});
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{
+            "{\n"
+            "  \"x\": 5\n"
+            "}"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(Url{server->GetBaseUrl() + "/patch.html"}, responses.at(0).url);
+    EXPECT_EQ(std::string{"application/json"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformAPITests, MultiperformApiSinglePostTest) {
+    std::vector<Response> responses = MultiPost(std::tuple<Url, Payload>{Url{server->GetBaseUrl() + "/url_post.html"}, Payload{{"x", "5"}}});
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{
+            "{\n"
+            "  \"x\": 5\n"
+            "}"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(Url{server->GetBaseUrl() + "/url_post.html"}, responses.at(0).url);
+    EXPECT_EQ(std::string{"application/json"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(201, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
 }
 
 int main(int argc, char** argv) {

--- a/test/multiperform_tests.cpp
+++ b/test/multiperform_tests.cpp
@@ -1,0 +1,128 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <cpr/cpr.h>
+#include <curl/curl.h>
+
+#include "httpServer.hpp"
+#include "httpsServer.hpp"
+
+using namespace cpr;
+
+static HttpServer* server = new HttpServer();
+
+TEST(MultiperformTests, MultiperformSingleSessionGetTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    std::vector<Response> responses = multiperform.Get();
+
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{"Hello world!"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformTests, MultiperformTwoSessionsGetTest) {
+    MultiPerform multiperform;
+    std::vector<Url> urls;
+    urls.push_back({server->GetBaseUrl() + "/hello.html"});
+    urls.push_back({server->GetBaseUrl() + "/error.html"});
+
+    std::vector<std::shared_ptr<Session>> sessions;
+    sessions.push_back(std::make_shared<Session>());
+    sessions.push_back(std::make_shared<Session>());
+
+
+    for (size_t i = 0; i < sessions.size(); ++i) {
+        sessions.at(i)->SetUrl(urls.at(i));
+        multiperform.AddSession(sessions.at(i));
+    }
+
+    std::vector<Response> responses = multiperform.Get();
+
+    EXPECT_EQ(responses.size(), sessions.size());
+    std::vector<std::string> expected_texts;
+    expected_texts.push_back("Hello world!");
+    expected_texts.push_back("Not Found");
+
+    std::vector<std::string> expected_content_types;
+    expected_content_types.push_back("text/html");
+    expected_content_types.push_back("text/plain");
+
+    std::vector<long> expected_status_codes;
+    expected_status_codes.push_back(200);
+    expected_status_codes.push_back(404);
+
+    for (size_t i = 0; i < responses.size(); ++i) {
+        EXPECT_EQ(expected_texts.at(i), responses.at(i).text);
+        EXPECT_EQ(urls.at(i), responses.at(i).url);
+        EXPECT_EQ(expected_content_types.at(i), responses.at(i).header["content-type"]);
+        EXPECT_EQ(expected_status_codes.at(i), responses.at(i).status_code);
+        EXPECT_EQ(ErrorCode::OK, responses.at(i).error.code);
+    }
+}
+
+TEST(MultiperformTests, MultiperformRemoveSessionGetTest) {
+    MultiPerform multiperform;
+    std::vector<Url> urls;
+    urls.push_back({server->GetBaseUrl() + "/hello.html"});
+    urls.push_back({server->GetBaseUrl() + "/hello.html"});
+
+    std::vector<std::shared_ptr<Session>> sessions;
+    sessions.push_back(std::make_shared<Session>());
+    sessions.push_back(std::make_shared<Session>());
+
+
+    for (size_t i = 0; i < sessions.size(); ++i) {
+        sessions.at(i)->SetUrl(urls.at(i));
+        multiperform.AddSession(sessions.at(i));
+    }
+
+    multiperform.RemoveSession(sessions.at(0));
+
+    std::vector<Response> responses = multiperform.Get();
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{"Hello world!"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(urls.at(0), responses.at(0).url);
+    EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformTests, MultiperformTenSessionsGetTest) {
+    MultiPerform multiperform;
+    std::vector<Url> urls;
+    std::vector<std::shared_ptr<Session>> sessions;
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    for (size_t i = 0; i < 10; ++i) {
+        urls.push_back(url);
+        sessions.push_back(std::make_shared<Session>());
+        sessions.at(i)->SetUrl(urls.at(i));
+        multiperform.AddSession(sessions.at(i));
+    }
+
+    std::vector<Response> responses = multiperform.Get();
+
+    EXPECT_EQ(responses.size(), 10);
+    for (Response& response : responses) {
+        EXPECT_EQ(std::string{"Hello world!"}, response.text);
+        EXPECT_EQ(url, response.url);
+        EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+        EXPECT_EQ(200, response.status_code);
+        EXPECT_EQ(ErrorCode::OK, response.error.code);
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(server);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# Progress
- [x] Implement more request methods
- [x] Implement interface which does implicitly create session objects
- [x] Tests
- [x] Documentation

# Issue
- Closes #556 

# Implementation

## Class: CurlMultiHolder
- `cpr::CurlMultiHolder` is similar to `cpr::CurlHolder` and is a RAII wrapper for the used `CURLM` handle which is created using [curl_multi_init](https://curl.se/libcurl/c/curl_multi_init.html)

## Class: MultiPerform
- Implemented new class `cpr::MultiPerform` with the following public interface:
  ```c++
  class MultiPerform {
    public:
      enum class HttpMethod {
        UNDEFINED = 0,
        GET_REQUEST,
        POST_REQUEST,
        PUT_REQUEST,
        DELETE_REQUEST,
        PATCH_REQUEST,
        HEAD_REQUEST,
        OPTIONS_REQUEST,
        DOWNLOAD_REQUEST,
      };
      
      MultiPerform();
      std::vector<Response> Get();
      std::vector<Response> Delete();
      std::vector<Response> Put();
      std::vector<Response> Head();
      std::vector<Response> Options();
      std::vector<Response> Patch();
      std::vector<Response> Post();
      template <typename... DownloadArgTypes>
      std::vector<Response> Download(DownloadArgTypes... args);

      std::vector<Response> Perform();
      template <typename... DownloadArgTypes>
      std::vector<Response> PerformDownload(DownloadArgTypes... args);

      void AddSession(std::shared_ptr<Session>& session, HttpMethod method = HttpMethod::UNDEFINED);
      void RemoveSession(const std::shared_ptr<Session>& session);
  }
  ```
  - `AddSession` and `RemoveSession` can be used to add and remove sessions from the multi perform handle which also locks / unlocks the session for the standalone use without multi handle.
  - The `Perform` function is only interesting when using `AddSession` with the method parameter. If the method parameter is set when adding the respective session, `Perform` will perform the specified HTTP method on the session object. This makes it possible to execute several different request methods in one Multi Perform.
  Note: One can not mix `DOWNLOAD_REQUEST` with any other request type.
  - The functions `Get`, `Delete`, `Put`, `Head`, `Options`, `Patch`, `Post`, and `Download` can be used to perform the respective http request on every added session
- Internally, every `cpr::MultiPerform`  object holds a vector of pairs of added session objects together with their specified request type and a `cpr::CurlMultiHolder`
  ```c++
  std::vector<std::pair<std::shared_ptr<Session>, HttpMethod>> sessions_;
  std::unique_ptr<CurlMultiHolder> multicurl_;
  ```
- When a request is performed the following steps are done:
  1. Call prepare function (e.g. PrepareGet()) on every session object
  2. Do multi perform using [curl_multi_perform](https://curl.se/libcurl/c/curl_multi_perform.html) and [curl_multi_poll](https://curl.se/libcurl/c/curl_multi_poll.html) until every handle has finished
  3. Get infos and create Response objects for all requests using [curl_multi_info_read](https://curl.se/libcurl/c/curl_multi_info_read.html)

## API Functions for Simplified Usage
- Implemented the following functions to simplify the usage for base cases:
  - `cpr::MultiGet`
  - `cpr::MultiDelete`
  - `cpr::MultiPut`
  - `cpr::MultiHead`
  - `cpr::MultiOptions`
  - `cpr::MultiPatch`
  - `cpr::MultiPost`
- All these functions have the same structure and for example `cpr::MultiGet(...)` can be used to implicitly create a `cpr::CurlMultiHolder` object which automatically creates `cpr::Session` objects, adds them to the multi holder and performs a multi get request on them. In order to set different options for different sessions, one can simply pass multiple tuples (the number of tuples determines how many sessions will be created) containing the session options.

**Example:**
The following request will create two session objects and performs a get request to 'https://example.com'. Moreover, for the first request a timeout is set.
```c++
std::vector<Response> responses = MultiGet(std::tuple<Url, Timeout>{Url{"https://example.com"}, Timeout{1000}}, std::tuple<Url>{Url{"https://example.com"}});

```
