### PR TITLE
Securely remove sensitive data from memory

### DIFF
--- a/cpr/auth.cpp
+++ b/cpr/auth.cpp
@@ -1,6 +1,11 @@
 #include "cpr/auth.h"
+#include "cpr/util.h"
 
 namespace cpr {
+Authentication::~Authentication() noexcept {
+    util::secureStringClear(auth_string_);
+}
+
 const char* Authentication::GetAuthString() const noexcept {
     return auth_string_.c_str();
 }

--- a/cpr/bearer.cpp
+++ b/cpr/bearer.cpp
@@ -1,9 +1,14 @@
 #include "cpr/bearer.h"
+#include "cpr/util.h"
 
 namespace cpr {
 // Only supported with libcurl >= 7.61.0.
 // As an alternative use SetHeader and add the token manually.
 #if LIBCURL_VERSION_NUM >= 0x073D00
+Bearer::~Bearer() noexcept {
+    util::secureStringClear(token_string_);
+}
+
 const char* Bearer::GetToken() const noexcept {
     return token_string_.c_str();
 }

--- a/cpr/proxyauth.cpp
+++ b/cpr/proxyauth.cpp
@@ -1,6 +1,11 @@
 #include "cpr/proxyauth.h"
+#include "cpr/util.h"
 
 namespace cpr {
+EncodedAuthentication::~EncodedAuthentication() noexcept {
+    util::secureStringClear(auth_string_);
+}
+
 const char* EncodedAuthentication::GetAuthString() const noexcept {
     return auth_string_.c_str();
 }

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -11,10 +11,10 @@
 #include <string>
 #include <vector>
 
-#if !defined(_Win32)
-#include <cstring>
-#else
+#if defined(_Win32)
 #include <Windows.h>
+#else
+#include <cstring>
 #endif
 
 namespace cpr {
@@ -127,7 +127,7 @@ int progressUserFunction(const ProgressCallback* progress, double dltotal, doubl
 int progressUserFunction(const ProgressCallback* progress, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
 #endif
     return (*progress)(dltotal, dlnow, ultotal, ulnow) ? 0 : 1;
-} // namespace util
+}
 
 int debugUserFunction(CURL* /*handle*/, curl_infotype type, char* data, size_t size, const DebugCallback* debug) {
     (*debug)(DebugCallback::InfoType(type), std::string(data, size));
@@ -174,7 +174,7 @@ void secureStringClear(std::string& s) {
 #if defined(__linux__) || defined(__unix__)
     explicit_bzero(&s.front(), s.length());
 #elif defined(_WIN32)
-    SecureZeroMemory(&s.front(), s.length())
+    SecureZeroMemory(&s.front(), s.length());
 #elif defined(__STDC_LIB_EXT1__)
     memset_s(&s.front(), s.length(), 0, s.length());
 #else

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -178,7 +178,14 @@ void secureStringClear(std::string& s) {
 #elif defined(__STDC_LIB_EXT1__)
     memset_s(&s.front(), s.length(), 0, s.length());
 #else
-#warning "Security: Secure memory erasure not supported on this platform"
+#pragma GCC push_options // g++
+#pragma GCC optimize ("O0") // g++
+#pragma clang optimize off // clang
+#pragma optimize("", off) // MSVC
+    std::memset(s.data(), 0, s.length());
+#pragma optimize("", on) // MSVC
+#pragma clang optimize on // clang
+#pragma GCC pop_options // g++
 #endif
     s.clear();
 }

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -15,7 +15,7 @@ class Authentication {
     Authentication(std::string&& username, std::string&& password, const AuthMode&& auth_mode) : auth_string_{std::move(username) + ":" + std::move(password)}, auth_mode_{std::move(auth_mode)} {}
     Authentication(const Authentication& other) = default;
     Authentication(Authentication&& old) noexcept = default;
-    ~Authentication() noexcept = default;
+    ~Authentication() noexcept;
 
     Authentication& operator=(Authentication&& old) noexcept = default;
     Authentication& operator=(const Authentication& other) = default;

--- a/include/cpr/bearer.h
+++ b/include/cpr/bearer.h
@@ -19,7 +19,7 @@ class Bearer {
     Bearer(std::string&& token) : token_string_{std::move(token)} {}
     Bearer(const Bearer& other) = default;
     Bearer(Bearer&& old) noexcept = default;
-    virtual ~Bearer() noexcept = default;
+    virtual ~Bearer() noexcept;
 
     Bearer& operator=(Bearer&& old) noexcept = default;
     Bearer& operator=(const Bearer& other) = default;

--- a/include/cpr/proxyauth.h
+++ b/include/cpr/proxyauth.h
@@ -15,7 +15,7 @@ class EncodedAuthentication {
     EncodedAuthentication(std::string&& username, std::string&& password) : auth_string_{cpr::util::urlEncode(std::move(username)) + ":" + cpr::util::urlEncode(std::move(password))} {}
     EncodedAuthentication(const EncodedAuthentication& other) = default;
     EncodedAuthentication(EncodedAuthentication&& old) noexcept = default;
-    virtual ~EncodedAuthentication() noexcept = default;
+    virtual ~EncodedAuthentication() noexcept;
 
     EncodedAuthentication& operator=(EncodedAuthentication&& old) noexcept = default;
     EncodedAuthentication& operator=(const EncodedAuthentication& other) = default;

--- a/include/cpr/ssl_options.h
+++ b/include/cpr/ssl_options.h
@@ -7,6 +7,7 @@
 
 #include <curl/curl.h>
 
+#include "util.h"
 #include <utility>
 
 #define __LIBCURL_VERSION_GTE(major, minor) ((LIBCURL_VERSION_MAJOR > (major)) || ((LIBCURL_VERSION_MAJOR == (major)) && (LIBCURL_VERSION_MINOR >= (minor))))
@@ -123,7 +124,9 @@ class KeyFile {
     template <typename FileType, typename PassType>
     KeyFile(FileType&& p_filename, PassType p_password) : filename(std::forward<FileType>(p_filename)), password(std::move(p_password)) {}
 
-    virtual ~KeyFile() = default;
+    virtual ~KeyFile() {
+        util::secureStringClear(password);
+    }
 
     std::string filename;
     std::string password;
@@ -142,7 +145,9 @@ class KeyBlob {
     template <typename BlobType, typename PassType>
     KeyBlob(BlobType&& p_blob, PassType p_password) : blob(std::forward<BlobType>(p_blob)), password(std::move(p_password)) {}
 
-    virtual ~KeyBlob() = default;
+    virtual ~KeyBlob() {
+        util::secureStringClear(password);
+    }
 
     std::string blob;
     std::string password;
@@ -445,6 +450,13 @@ struct SslOptions {
 #if SUPPORT_SESSIONID_CACHE
     bool session_id_cache = true;
 #endif
+
+    ~SslOptions() noexcept {
+#if SUPPORT_CURLOPT_SSLKEY_BLOB
+        util::secureStringClear(key_blob);
+#endif
+        util::secureStringClear(key_pass);
+    }
 
     void SetOption(const ssl::CertFile& opt) {
         cert_file = opt.filename;

--- a/include/cpr/ssl_options.h
+++ b/include/cpr/ssl_options.h
@@ -7,7 +7,7 @@
 
 #include <curl/curl.h>
 
-#include "util.h"
+#include "cpr/util.h"
 #include <utility>
 
 #define __LIBCURL_VERSION_GTE(major, minor) ((LIBCURL_VERSION_MAJOR > (major)) || ((LIBCURL_VERSION_MAJOR == (major)) && (LIBCURL_VERSION_MINOR >= (minor))))

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -29,7 +29,7 @@ int debugUserFunction(CURL* handle, curl_infotype type, char* data, size_t size,
 std::vector<std::string> split(const std::string& to_split, char delimiter);
 std::string urlEncode(const std::string& s);
 std::string urlDecode(const std::string& s);
-
+void secureStringClear(std::string& s);
 } // namespace util
 } // namespace cpr
 


### PR DESCRIPTION
This PR introduces explicit removal of sensitive data from memory. Once a string holding a password or certificate is destructed, the associated memory gets overridden. This reduces the time frame in which attackers can steal credentials, e.g. by examining a core dump or by exploiting a memory vulnerability.