### PR TITLE
Refactor cpr::Cookies for storing more fields (#777)

### DIFF
--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -1,51 +1,107 @@
 #include "cpr/cookies.h"
 
 namespace cpr {
-std::string Cookies::GetEncoded(const CurlHolder& holder) const {
+const std::string Cookie::GetDomain() const {
+    return domain_;
+}
+
+bool Cookie::IsIncludingSubdomains() const {
+    return includeSubdomains_;
+}
+
+const std::string Cookie::GetPath() const {
+    return path_;
+}
+
+bool Cookie::IsHttpsOnly() const {
+    return httpsOnly_;
+}
+
+
+/**
+ * TODO: Update the implementation using `std::chrono::utc_clock` of C++20
+ */
+const std::chrono::time_point<std::chrono::system_clock> Cookie::GetExpires() const {
+    return std::chrono::system_clock::from_time_t(expires_);
+}
+
+const std::string Cookie::GetExpiresString() const {
+    std::stringstream ss;
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &expires_);
+#else
+    gmtime_r(&expires_, &tm);
+#endif
+    ss << std::put_time(&tm, "%a, %d %b %Y %H:%M:%S GMT");
+    return ss.str();
+}
+
+const std::string Cookie::GetName() const {
+    return name_;
+}
+
+const std::string Cookie::GetValue() const {
+    return value_;
+}
+
+const std::string Cookies::GetEncoded(const CurlHolder& holder) const {
     std::stringstream stream;
-    for (const std::pair<const std::string, std::string>& item : map_) {
+    for (const cpr::Cookie& item : cookies_) {
         // Depending on if encoding is set to "true", we will URL-encode cookies
-        stream << (encode ? holder.urlEncode(item.first) : item.first) << "=";
+        stream << (encode ? holder.urlEncode(item.GetName()) : item.GetName()) << "=";
 
         // special case version 1 cookies, which can be distinguished by
         // beginning and trailing quotes
-        if (!item.second.empty() && item.second.front() == '"' && item.second.back() == '"') {
-            stream << item.second;
+        if (!item.GetValue().empty() && item.GetValue().front() == '"' && item.GetValue().back() == '"') {
+            stream << item.GetValue();
         } else {
             // Depending on if encoding is set to "true", we will URL-encode cookies
-            stream << (encode ? holder.urlEncode(item.second) : item.second);
+            stream << (encode ? holder.urlEncode(item.GetValue()) : item.GetValue());
         }
         stream << "; ";
     }
     return stream.str();
 }
 
-std::string& Cookies::operator[](const std::string& key) {
-    return map_[key];
+cpr::Cookie& Cookies::operator[](size_t pos) {
+    return cookies_[pos];
 }
 
 Cookies::iterator Cookies::begin() {
-    return map_.begin();
+    return cookies_.begin();
 }
 
 Cookies::iterator Cookies::end() {
-    return map_.end();
+    return cookies_.end();
 }
 
 Cookies::const_iterator Cookies::begin() const {
-    return map_.begin();
+    return cookies_.begin();
 }
 
 Cookies::const_iterator Cookies::end() const {
-    return map_.end();
+    return cookies_.end();
 }
 
 Cookies::const_iterator Cookies::cbegin() const {
-    return map_.cbegin();
+    return cookies_.cbegin();
 }
 
 Cookies::const_iterator Cookies::cend() const {
-    return map_.cend();
+    return cookies_.cend();
+}
+
+void Cookies::emplace_back(const Cookie& str) {
+    cookies_.emplace_back(str);
+}
+
+void Cookies::push_back(const Cookie& str) {
+    cookies_.push_back(str);
+}
+
+void Cookies::pop_back() {
+    cookies_.pop_back();
 }
 
 } // namespace cpr

--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -1,4 +1,5 @@
 #include "cpr/cookies.h"
+#include <ctime>
 
 namespace cpr {
 const std::string Cookie::GetDomain() const {
@@ -17,21 +18,18 @@ bool Cookie::IsHttpsOnly() const {
     return httpsOnly_;
 }
 
-
-/**
- * TODO: Update the implementation using `std::chrono::utc_clock` of C++20
- */
 const std::chrono::time_point<std::chrono::system_clock> Cookie::GetExpires() const {
-    return std::chrono::system_clock::from_time_t(expires_);
+    return expires_;
 }
 
 const std::string Cookie::GetExpiresString() const {
     std::stringstream ss;
     std::tm tm{};
+    std::time_t tt = std::chrono::system_clock::to_time_t(expires_);
 #ifdef _WIN32
     gmtime_s(&tm, &expires_);
 #else
-    gmtime_r(&expires_, &tm);
+    gmtime_r(&tt, &tm);
 #endif
     ss << std::put_time(&tm, "%a, %d %b %Y %H:%M:%S GMT");
     return ss.str();

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -24,7 +24,7 @@ namespace cpr {
 namespace util {
 
 enum class CurlHTTPCookieField : size_t {
-    Domain,
+    Domain = 0,
     IncludeSubdomains,
     Path,
     HttpsOnly,

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -34,7 +34,7 @@ enum class CurlHTTPCookieField : size_t {
 };
 
 Cookies parseCookies(curl_slist* raw_cookies) {
-    const int CURL_HTTP_COOKIE_SIZE(7);
+    const int CURL_HTTP_COOKIE_SIZE = static_cast<int>(CurlHTTPCookieField::Value) + 1;
     Cookies cookies;
     for (curl_slist* nc = raw_cookies; nc; nc = nc->next) {
         std::vector<std::string> tokens = cpr::util::split(nc->data, '\t');

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <chrono>
 #include <cstdint>
 #include <fstream>
 #include <iomanip>
@@ -41,6 +42,7 @@ Cookies parseCookies(curl_slist* raw_cookies) {
         while (tokens.size() < CURL_HTTP_COOKIE_SIZE) {
             tokens.emplace_back("");
         }
+        std::time_t expires = static_cast<time_t>(std::stoul(tokens.at(static_cast<size_t>(CurlHTTPCookieField::Expires))));
         cookies.emplace_back(Cookie{
                 tokens.at(static_cast<size_t>(CurlHTTPCookieField::Name)),
                 tokens.at(static_cast<size_t>(CurlHTTPCookieField::Value)),
@@ -48,7 +50,7 @@ Cookies parseCookies(curl_slist* raw_cookies) {
                 isTrue(tokens.at(static_cast<size_t>(CurlHTTPCookieField::IncludeSubdomains))),
                 tokens.at(static_cast<size_t>(CurlHTTPCookieField::Path)),
                 isTrue(tokens.at(static_cast<size_t>(CurlHTTPCookieField::HttpsOnly))),
-                static_cast<time_t>(std::stoul(tokens.at(static_cast<size_t>(CurlHTTPCookieField::Expires)))),
+                std::chrono::system_clock::from_time_t(expires),
         });
     }
     return cookies;

--- a/include/cpr/cookies.h
+++ b/include/cpr/cookies.h
@@ -19,7 +19,7 @@ static const std::size_t EXPIRES_STRING_SIZE = 100;
 class Cookie {
   public:
     Cookie() = default;
-    Cookie(const std::string& name, const std::string& value, const std::string& domain = "", bool p_isIncludingSubdomains = false, const std::string& path = "/", bool p_isHttpsOnly = false, std::time_t expires = 0) : name_{name}, value_{value}, domain_{domain}, includeSubdomains_{p_isIncludingSubdomains}, path_{path}, httpsOnly_{p_isHttpsOnly}, expires_{expires} {};
+    Cookie(const std::string& name, const std::string& value, const std::string& domain = "", bool p_isIncludingSubdomains = false, const std::string& path = "/", bool p_isHttpsOnly = false, std::chrono::time_point<std::chrono::system_clock> expires = std::chrono::time_point<std::chrono::system_clock>::min()) : name_{name}, value_{value}, domain_{domain}, includeSubdomains_{p_isIncludingSubdomains}, path_{path}, httpsOnly_{p_isHttpsOnly}, expires_{expires} {};
     const std::string GetDomain() const;
     bool IsIncludingSubdomains() const;
     const std::string GetPath() const;
@@ -36,7 +36,10 @@ class Cookie {
     bool includeSubdomains_{};
     std::string path_;
     bool httpsOnly_{};
-    std::time_t expires_{};
+    /**
+     * TODO: Update the implementation using `std::chrono::utc_clock` of C++20
+     **/
+    std::chrono::time_point<std::chrono::system_clock> expires_{};
 };
 
 class Cookies {

--- a/include/cpr/cookies.h
+++ b/include/cpr/cookies.h
@@ -4,7 +4,6 @@
 #include "cpr/curlholder.h"
 #include <chrono>
 #include <initializer_list>
-#include <iomanip>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/include/cpr/cookies.h
+++ b/include/cpr/cookies.h
@@ -2,12 +2,42 @@
 #define CPR_COOKIES_H
 
 #include "cpr/curlholder.h"
+#include <chrono>
 #include <initializer_list>
-#include <map>
+#include <iomanip>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace cpr {
+/**
+ * EXPIRES_STRING_SIZE is an explicitly static and const variable that could be only accessed within the same namespace and is immutable.
+ * To be used for "std::array", the expression must have a constant value, so EXPIRES_STRING_SIZE must be a const value.
+ **/
+static const std::size_t EXPIRES_STRING_SIZE = 100;
+
+class Cookie {
+  public:
+    Cookie() = default;
+    Cookie(const std::string& name, const std::string& value, const std::string& domain = "", bool p_isIncludingSubdomains = false, const std::string& path = "/", bool p_isHttpsOnly = false, std::time_t expires = 0) : name_{name}, value_{value}, domain_{domain}, includeSubdomains_{p_isIncludingSubdomains}, path_{path}, httpsOnly_{p_isHttpsOnly}, expires_{expires} {};
+    const std::string GetDomain() const;
+    bool IsIncludingSubdomains() const;
+    const std::string GetPath() const;
+    bool IsHttpsOnly() const;
+    const std::chrono::time_point<std::chrono::system_clock> GetExpires() const;
+    const std::string GetExpiresString() const;
+    const std::string GetName() const;
+    const std::string GetValue() const;
+
+  private:
+    std::string name_;
+    std::string value_;
+    std::string domain_;
+    bool includeSubdomains_{};
+    std::string path_;
+    bool httpsOnly_{};
+    std::time_t expires_{};
+};
 
 class Cookies {
   public:
@@ -25,16 +55,16 @@ class Cookies {
     bool encode{true};
 
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Cookies(bool p_encode = true) : encode(p_encode) {}
-    Cookies(const std::initializer_list<std::pair<const std::string, std::string>>& pairs, bool p_encode = true) : encode(p_encode), map_{pairs} {}
+    Cookies(bool p_encode = true) : encode{p_encode} {};
+    Cookies(const std::initializer_list<cpr::Cookie>& cookies, bool p_encode = true) : encode{p_encode}, cookies_{cookies} {};
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Cookies(const std::map<std::string, std::string>& map, bool p_encode = true) : encode(p_encode), map_{map} {}
+    Cookies(const cpr::Cookie& cookie, bool p_encode = true) : encode{p_encode}, cookies_{cookie} {};
 
-    std::string& operator[](const std::string& key);
-    std::string GetEncoded(const CurlHolder& holder) const;
+    cpr::Cookie& operator[](size_t pos);
+    const std::string GetEncoded(const CurlHolder& holder) const;
 
-    using iterator = std::map<std::string, std::string>::iterator;
-    using const_iterator = std::map<std::string, std::string>::const_iterator;
+    using iterator = std::vector<cpr::Cookie>::iterator;
+    using const_iterator = std::vector<cpr::Cookie>::const_iterator;
 
     iterator begin();
     iterator end();
@@ -42,9 +72,12 @@ class Cookies {
     const_iterator end() const;
     const_iterator cbegin() const;
     const_iterator cend() const;
+    void emplace_back(const Cookie& str);
+    void push_back(const Cookie& str);
+    void pop_back();
 
   private:
-    std::map<std::string, std::string> map_;
+    std::vector<cpr::Cookie> cookies_;
 };
 
 } // namespace cpr

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -37,6 +37,8 @@ std::string urlDecode(const std::string& s);
  * https://github.com/ojeda/secure_clear/blob/master/example-implementation/secure_clear.h
  **/
 void secureStringClear(std::string& s);
+bool isTrue(const std::string& s);
+
 } // namespace util
 } // namespace cpr
 

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -85,64 +85,64 @@ TEST(BasicTests, BadHostTest) {
     EXPECT_EQ(ErrorCode::HOST_RESOLUTION_FAILURE, response.error.code);
 }
 
-TEST(CookiesTests, SingleCookieTest) {
+TEST(CookiesTests, BasicCookiesTest) {
     Url url{server->GetBaseUrl() + "/basic_cookies.html"};
-    Cookies cookies{{"hello", "world"}, {"my", "another; fake=cookie;"}};
-    Response response = cpr::Get(url, cookies);
-    std::string expected_text{"Hello world!"};
+    Response response = cpr::Get(url);
+    cpr::Cookies res_cookies{response.cookies};
+    std::string expected_text{"Basic Cookies"};
+    cpr::Cookies expectedCookies{
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, 3905119080},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, 3905119080},
+    };
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
-    cookies = response.cookies;
-    EXPECT_EQ(cookies["cookie"], response.cookies["cookie"]);
-    EXPECT_EQ(cookies["icecream"], response.cookies["icecream"]);
-    EXPECT_EQ(cookies["expires"], response.cookies["expires"]);
+    for (auto cookie = res_cookies.begin(), expectedCookie = expectedCookies.begin(); cookie != res_cookies.end() && expectedCookie != expectedCookies.end(); cookie++, expectedCookie++) {
+        EXPECT_EQ(expectedCookie->GetName(), cookie->GetName());
+        EXPECT_EQ(expectedCookie->GetValue(), cookie->GetValue());
+        EXPECT_EQ(expectedCookie->GetDomain(), cookie->GetDomain());
+        EXPECT_EQ(expectedCookie->IsIncludingSubdomains(), cookie->IsIncludingSubdomains());
+        EXPECT_EQ(expectedCookie->GetPath(), cookie->GetPath());
+        EXPECT_EQ(expectedCookie->IsHttpsOnly(), cookie->IsHttpsOnly());
+        EXPECT_EQ(expectedCookie->GetExpires(), cookie->GetExpires());
+    }
 }
 
 TEST(CookiesTests, EmptyCookieTest) {
     Url url{server->GetBaseUrl() + "/empty_cookies.html"};
     Response response = cpr::Get(url);
-    EXPECT_EQ(url, response.url);
-    EXPECT_EQ(200, response.status_code);
-    EXPECT_EQ(ErrorCode::OK, response.error.code);
-    EXPECT_EQ("", response.cookies["cookie"]);
-    EXPECT_EQ("", response.cookies["icecream"]);
-}
-
-TEST(CookiesTests, CheckBasicCookieTest) {
-    // server validates whether the cookies are indeed present
-    Url url{server->GetBaseUrl() + "/check_cookies.html"};
-    Cookies cookies{{"cookie", "chocolate"}, {"icecream", "vanilla"}};
-    Response response = cpr::Get(url, cookies);
-    std::string expected_text{"Hello world!"};
-    EXPECT_EQ(expected_text, response.text);
+    cpr::Cookies res_cookies{response.cookies};
+    std::string expected_text{"Empty Cookies"};
+    cpr::Cookies expectedCookies{
+            {"SID", "", "127.0.0.1", false, "/", true, 3905119080},
+            {"lang", "", "127.0.0.1", false, "/", true, 3905119080},
+    };
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
-}
-
-TEST(CookiesTests, V1CookieTest) {
-    Url url{server->GetBaseUrl() + "/v1_cookies.html"};
-    Response response = cpr::Get(url);
-    std::string expected_text{"Hello world!"};
     EXPECT_EQ(expected_text, response.text);
-    EXPECT_EQ(url, response.url);
-    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
-    EXPECT_EQ(200, response.status_code);
-    EXPECT_EQ(ErrorCode::OK, response.error.code);
-    Cookies cookies = response.cookies;
-    EXPECT_EQ("\"value with spaces (v1 cookie)\"", cookies["cookie"]);
+    for (auto cookie = res_cookies.begin(), expectedCookie = expectedCookies.begin(); cookie != res_cookies.end() && expectedCookie != expectedCookies.end(); cookie++, expectedCookie++) {
+        EXPECT_EQ(expectedCookie->GetName(), cookie->GetName());
+        EXPECT_EQ(expectedCookie->GetValue(), cookie->GetValue());
+        EXPECT_EQ(expectedCookie->GetDomain(), cookie->GetDomain());
+        EXPECT_EQ(expectedCookie->IsIncludingSubdomains(), cookie->IsIncludingSubdomains());
+        EXPECT_EQ(expectedCookie->GetPath(), cookie->GetPath());
+        EXPECT_EQ(expectedCookie->IsHttpsOnly(), cookie->IsHttpsOnly());
+        EXPECT_EQ(expectedCookie->GetExpires(), cookie->GetExpires());
+    }
 }
 
-TEST(CookiesTests, CheckV1CookieTest) {
-    // server validates whether the cookie is indeed present
-    Url url{server->GetBaseUrl() + "/check_v1_cookies.html"};
-    Cookies cookies{{"cookie", "\"value with spaces (v1 cookie)\""}};
+TEST(CookiesTests, ClientSetCookiesTest) {
+    Url url{server->GetBaseUrl() + "/cookies_reflect.html"};
+    Cookies cookies{
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, 3905119080},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, 3905119080},
+    };
     Response response = cpr::Get(url, cookies);
-    std::string expected_text{"Hello world!"};
+    std::string expected_text{"SID=31d4d96e407aad42; lang=en-US;"};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -91,8 +91,8 @@ TEST(CookiesTests, BasicCookiesTest) {
     cpr::Cookies res_cookies{response.cookies};
     std::string expected_text{"Basic Cookies"};
     cpr::Cookies expectedCookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, 3905119080},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, 3905119080},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
     };
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
@@ -116,8 +116,8 @@ TEST(CookiesTests, EmptyCookieTest) {
     cpr::Cookies res_cookies{response.cookies};
     std::string expected_text{"Empty Cookies"};
     cpr::Cookies expectedCookies{
-            {"SID", "", "127.0.0.1", false, "/", true, 3905119080},
-            {"lang", "", "127.0.0.1", false, "/", true, 3905119080},
+            {"SID", "", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"lang", "", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
     };
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
@@ -138,8 +138,8 @@ TEST(CookiesTests, EmptyCookieTest) {
 TEST(CookiesTests, ClientSetCookiesTest) {
     Url url{server->GetBaseUrl() + "/cookies_reflect.html"};
     Cookies cookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, 3905119080},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, 3905119080},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
     };
     Response response = cpr::Get(url, cookies);
     std::string expected_text{"SID=31d4d96e407aad42; lang=en-US;"};

--- a/test/head_tests.cpp
+++ b/test/head_tests.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <gtest/gtest.h>
 
 #include <string>
@@ -53,8 +54,8 @@ TEST(HeadTests, CookieHeadTest) {
     Url url{server->GetBaseUrl() + "/basic_cookies.html"};
     Response response = cpr::Head(url);
     cpr::Cookies expectedCookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, 3905119080},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, 3905119080},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
     };
     cpr::Cookies res_cookies{response.cookies};
     EXPECT_EQ(std::string{}, response.text);

--- a/test/head_tests.cpp
+++ b/test/head_tests.cpp
@@ -51,17 +51,26 @@ TEST(HeadTests, BadHostHeadTest) {
 
 TEST(HeadTests, CookieHeadTest) {
     Url url{server->GetBaseUrl() + "/basic_cookies.html"};
-    Cookies cookies{{"hello", "world"}, {"my", "another; fake=cookie;"}};
-    Response response = cpr::Head(url, cookies);
+    Response response = cpr::Head(url);
+    cpr::Cookies expectedCookies{
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, 3905119080},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, 3905119080},
+    };
+    cpr::Cookies res_cookies{response.cookies};
     EXPECT_EQ(std::string{}, response.text);
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
-    cookies = response.cookies;
-    EXPECT_EQ(cookies["cookie"], response.cookies["cookie"]);
-    EXPECT_EQ(cookies["icecream"], response.cookies["icecream"]);
-    EXPECT_EQ(cookies["expires"], response.cookies["expires"]);
+    for (auto cookie = res_cookies.begin(), expectedCookie = expectedCookies.begin(); cookie != res_cookies.end() && expectedCookie != expectedCookies.end(); cookie++, expectedCookie++) {
+        EXPECT_EQ(expectedCookie->GetName(), cookie->GetName());
+        EXPECT_EQ(expectedCookie->GetValue(), cookie->GetValue());
+        EXPECT_EQ(expectedCookie->GetDomain(), cookie->GetDomain());
+        EXPECT_EQ(expectedCookie->IsIncludingSubdomains(), cookie->IsIncludingSubdomains());
+        EXPECT_EQ(expectedCookie->GetPath(), cookie->GetPath());
+        EXPECT_EQ(expectedCookie->IsHttpsOnly(), cookie->IsHttpsOnly());
+        EXPECT_EQ(expectedCookie->GetExpires(), cookie->GetExpires());
+    }
 }
 
 TEST(HeadTests, ParameterHeadTest) {

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -102,89 +102,88 @@ void HttpServer::OnRequestLowSpeedBytes(mg_connection* conn, http_message* /*msg
 }
 
 void HttpServer::OnRequestBasicCookies(mg_connection* conn, http_message* /*msg*/) {
-    time_t t = time(nullptr) + 5; // Valid for 1 hour
-    char expire[100], expire_epoch[100];
-    snprintf(expire_epoch, sizeof(expire_epoch), "%lu", static_cast<unsigned long>(t));
-    strftime(expire, sizeof(expire), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&t));
-    std::string cookie{"cookie=chocolate; expires=\"" + std::string{expire} + "\"; http-only;"};
-    std::string cookie2{"icecream=vanilla; expires=\"" + std::string{expire} + "\"; http-only;"};
+    time_t expires_time = 3905119080; // Expires=Wed, 30 Sep 2093 03:18:00 GMT
+    std::array<char, EXPIRES_STRING_SIZE> expires_string;
+    std::strftime(expires_string.data(), expires_string.size(), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&expires_time));
+
+    std::string cookie1{"SID=31d4d96e407aad42; Expires=" + std::string(expires_string.data()) + "; Secure"};
+    std::string cookie2{"lang=en-US; Expires=" + std::string(expires_string.data()) + "; Secure"};
     std::string headers =
             "Content-Type: text/html\r\n"
             "Set-Cookie: " +
-            cookie +
+            cookie1 +
             "\r\n"
             "Set-Cookie: " +
             cookie2;
-    std::string response{"Hello world!"};
+    std::string response{"Basic Cookies"};
+
     mg_send_head(conn, 200, response.length(), headers.c_str());
     mg_send(conn, response.c_str(), response.length());
 }
 
 void HttpServer::OnRequestEmptyCookies(mg_connection* conn, http_message* /*msg*/) {
-    time_t t = time(nullptr) + 5; // Valid for 1 hour
-    char expire[100];
-    char expire_epoch[100];
-    snprintf(expire_epoch, sizeof(expire_epoch), "%lu", static_cast<unsigned long>(t));
-    strftime(expire, sizeof(expire), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&t));
-    std::string cookie{"cookie=; expires=\"" + std::string{expire} + "\"; http-only;"};
-    std::string cookie2{"icecream=; expires=\"" + std::string{expire} + "\"; http-only;"};
+    time_t expires_time = 3905119080; // Expires=Wed, 30 Sep 2093 03:18:00 GMT
+    std::array<char, EXPIRES_STRING_SIZE> expires_string;
+    std::strftime(expires_string.data(), sizeof(expires_string), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&expires_time));
+
+    std::string cookie1{"SID=; Expires=" + std::string(expires_string.data()) + "; Secure"};
+    std::string cookie2{"lang=; Expires=" + std::string(expires_string.data()) + "; Secure"};
     std::string headers =
             "Content-Type: text/html\r\n"
             "Set-Cookie: " +
-            cookie +
+            cookie1 +
             "\r\n"
             "Set-Cookie: " +
             cookie2;
-    std::string response{"Hello world!"};
+    std::string response{"Empty Cookies"};
+
     mg_send_head(conn, 200, response.length(), headers.c_str());
     mg_send(conn, response.c_str(), response.length());
 }
 
-void HttpServer::OnRequestCheckCookies(mg_connection* conn, http_message* msg) {
+void HttpServer::OnRequestCookiesReflect(mg_connection* conn, http_message* msg) {
     mg_str* request_cookies;
     if ((request_cookies = mg_get_http_header(msg, "Cookie")) == nullptr) {
         mg_http_send_error(conn, 400, "Cookie not found");
         return;
     }
     std::string cookie_str{request_cookies->p, request_cookies->len};
-
-    if (cookie_str.find("cookie=chocolate;") == cookie_str.npos || cookie_str.find("icecream=vanilla;") == cookie_str.npos) {
-        mg_http_send_error(conn, 400, "Cookies not found");
-    }
-
-    OnRequestHello(conn, msg);
+    std::string headers = "Content-Type: text/html";
+    mg_send_head(conn, 200, cookie_str.length(), headers.c_str());
+    mg_send(conn, cookie_str.c_str(), cookie_str.length());
 }
 
-void HttpServer::OnRequestV1Cookies(mg_connection* conn, http_message* /*msg*/) {
-    time_t t = time(nullptr) + 5; // Valid for 1 hour
-    char expire[100], expire_epoch[100];
-    snprintf(expire_epoch, sizeof(expire_epoch), "%lu", static_cast<unsigned long>(t));
-    strftime(expire, sizeof(expire), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&t));
-    std::string v1cookie{"cookie=\"value with spaces (v1 cookie)\"; expires=\"" + std::string{expire} + "\"; http-only;"};
+void HttpServer::OnRequestRedirectionWithChangingCookies(mg_connection* conn, http_message* msg) {
+    time_t expires_time = 3905119080; // Expires=Wed, 30 Sep 2093 03:18:00 GMT
+    std::array<char, EXPIRES_STRING_SIZE> expires_string;
+    std::strftime(expires_string.data(), sizeof(expires_string), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&expires_time));
 
-    std::string headers =
-            "Content-Type: text/html\r\n"
-            "Set-Cookie: " +
-            v1cookie;
-    std::string response{"Hello world!"};
-    mg_send_head(conn, 200, response.length(), headers.c_str());
-    mg_send(conn, response.c_str(), response.length());
-}
-
-void HttpServer::OnRequestCheckV1Cookies(mg_connection* conn, http_message* msg) {
     mg_str* request_cookies;
-    if ((request_cookies = mg_get_http_header(msg, "Cookie")) == nullptr) {
-        mg_http_send_error(conn, 400, "Cookie not found");
-        return;
-    }
-    std::string cookie_str{request_cookies->p, request_cookies->len};
-
-    if (cookie_str.find("cookie=\"value with spaces (v1 cookie)\";") == std::string::npos) {
-        mg_http_send_error(conn, 400, "Cookie with space not found");
-        return;
+    std::string cookie_str;
+    if ((request_cookies = mg_get_http_header(msg, "Cookie")) != nullptr) {
+        cookie_str = std::string{request_cookies->p, request_cookies->len};
     }
 
-    OnRequestHello(conn, msg);
+    if (cookie_str.find("SID=31d4d96e407aad42") == std::string::npos) {
+        std::string cookie1{"SID=31d4d96e407aad42; Expires=" + std::string(expires_string.data()) + "; Secure"};
+        std::string cookie2{"lang=en-US; Expires=" + std::string(expires_string.data()) + "; Secure"};
+        std::string headers =
+                "Content-Type: text/html\r\n"
+                "Location: http://127.0.0.1:61936/redirection_with_changing_cookies.html\r\n"
+                "Set-Cookie: " +
+                cookie1 +
+                "\r\n"
+                "Set-Cookie: " +
+                cookie2;
+
+        mg_send_head(conn, 302, 0, headers.c_str());
+        mg_send(conn, NULL, 0);
+    } else {
+        cookie_str = "Received cookies are: " + cookie_str;
+        std::string headers = "Content-Type: text/html";
+        mg_send_head(conn, 200, cookie_str.length(), headers.c_str());
+        mg_send(conn, cookie_str.c_str(), cookie_str.length());
+    }
 }
 
 void HttpServer::OnRequestBasicAuth(mg_connection* conn, http_message* msg) {
@@ -532,7 +531,7 @@ void HttpServer::OnRequestPut(mg_connection* conn, http_message* msg) {
     }
 }
 
-void HttpServer::OnRequestReflectPost(mg_connection* conn, http_message* msg) {
+void HttpServer::OnRequestPostReflect(mg_connection* conn, http_message* msg) {
     if (std::string{msg->method.p, msg->method.len} != std::string{"POST"}) {
         mg_http_send_error(conn, 405, "Method Not Allowed");
     }
@@ -799,12 +798,10 @@ void HttpServer::OnRequest(mg_connection* conn, http_message* msg) {
         OnRequestBasicCookies(conn, msg);
     } else if (uri == "/empty_cookies.html") {
         OnRequestEmptyCookies(conn, msg);
-    } else if (uri == "/check_cookies.html") {
-        OnRequestCheckCookies(conn, msg);
-    } else if (uri == "/v1_cookies.html") {
-        OnRequestV1Cookies(conn, msg);
-    } else if (uri == "/check_v1_cookies.html") {
-        OnRequestCheckV1Cookies(conn, msg);
+    } else if (uri == "/cookies_reflect.html") {
+        OnRequestCookiesReflect(conn, msg);
+    } else if (uri == "/redirection_with_changing_cookies.html") {
+        OnRequestRedirectionWithChangingCookies(conn, msg);
     } else if (uri == "/basic_auth.html") {
         OnRequestBasicAuth(conn, msg);
     } else if (uri == "/bearer_token.html") {
@@ -829,8 +826,8 @@ void HttpServer::OnRequest(mg_connection* conn, http_message* msg) {
         OnRequestJsonPost(conn, msg);
     } else if (uri == "/form_post.html") {
         OnRequestFormPost(conn, msg);
-    } else if (uri == "/reflect_post.html") {
-        OnRequestReflectPost(conn, msg);
+    } else if (uri == "/post_reflect.html") {
+        OnRequestPostReflect(conn, msg);
     } else if (uri == "/delete.html") {
         OnRequestDelete(conn, msg);
     } else if (uri == "/delete_unallowed.html") {

--- a/test/httpServer.hpp
+++ b/test/httpServer.hpp
@@ -29,9 +29,8 @@ class HttpServer : public AbstractServer {
     static void OnRequestLowSpeedBytes(mg_connection* conn, http_message* msg);
     static void OnRequestBasicCookies(mg_connection* conn, http_message* msg);
     static void OnRequestEmptyCookies(mg_connection* conn, http_message* msg);
-    static void OnRequestCheckCookies(mg_connection* conn, http_message* msg);
-    static void OnRequestV1Cookies(mg_connection* conn, http_message* msg);
-    static void OnRequestCheckV1Cookies(mg_connection* conn, http_message* msg);
+    static void OnRequestCookiesReflect(mg_connection* conn, http_message* msg);
+    static void OnRequestRedirectionWithChangingCookies(mg_connection* conn, http_message* msg);
     static void OnRequestBasicAuth(mg_connection* conn, http_message* msg);
     static void OnRequestBearerAuth(mg_connection* conn, http_message* msg);
     static void OnRequestBasicJson(mg_connection* conn, http_message* msg);
@@ -40,7 +39,7 @@ class HttpServer : public AbstractServer {
     static void OnRequestPermRedirect(mg_connection* conn, http_message* msg);
     static void OnRequestTwoRedirects(mg_connection* conn, http_message* msg);
     static void OnRequestUrlPost(mg_connection* conn, http_message* msg);
-    static void OnRequestReflectPost(mg_connection* conn, http_message* msg);
+    static void OnRequestPostReflect(mg_connection* conn, http_message* msg);
     static void OnRequestBodyGet(mg_connection* conn, http_message* msg);
     static void OnRequestJsonPost(mg_connection* conn, http_message* msg);
     static void OnRequestFormPost(mg_connection* conn, http_message* msg);

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -488,7 +488,7 @@ static std::string getTimestamp() {
 }
 
 TEST(UrlEncodedPostTests, PostReflectTest) {
-    std::string uri = server->GetBaseUrl() + "/reflect_post.html";
+    std::string uri = server->GetBaseUrl() + "/post_reflect.html";
     std::string body = R"({"property1": "value1"})";
     std::string contentType = "application/json";
     std::string signature = "x-ms-date: something";
@@ -515,7 +515,7 @@ TEST(UrlEncodedPostTests, PostReflectPayloadTest) {
 }
 
 TEST(UrlEncodedPostTests, InjectMultipleHeadersTest) {
-    std::string uri = server->GetBaseUrl() + "/reflect_post.html";
+    std::string uri = server->GetBaseUrl() + "/post_reflect.html";
     std::string key_1 = "key_1";
     std::string val_1 = "value_1";
     std::string key_2 = "key_2";
@@ -535,7 +535,7 @@ TEST(UrlEncodedPostTests, PostBodyWithFile) {
     test_file.open(filename);
     test_file << expected_text;
     test_file.close();
-    Url url{server->GetBaseUrl() + "/reflect_post.html"};
+    Url url{server->GetBaseUrl() + "/post_reflect.html"};
     cpr::Response response = Post(url, cpr::Header({{"Content-Type", "application/octet-stream"}}), cpr::Body(File("test_file")));
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
@@ -545,7 +545,7 @@ TEST(UrlEncodedPostTests, PostBodyWithFile) {
 }
 
 TEST(UrlEncodedPostTests, PostBodyWithBuffer) {
-    Url url{server->GetBaseUrl() + "/reflect_post.html"};
+    Url url{server->GetBaseUrl() + "/post_reflect.html"};
     std::string expected_text(R"({"property1": "value1"})");
     cpr::Response response = Post(url, cpr::Header({{"Content-Type", "application/octet-stream"}}), cpr::Body(Buffer{expected_text.begin(), expected_text.end(), "test_file"}));
     EXPECT_EQ(expected_text, response.text);

--- a/test/prepare_tests.cpp
+++ b/test/prepare_tests.cpp
@@ -63,7 +63,7 @@ TEST(PrepareTests, PatchTest) {
 
 TEST(PrepareTests, MultipleDeleteHeadPutGetPostTest) {
     Url url{server->GetBaseUrl() + "/header_reflect.html"};
-    Url urlPost{server->GetBaseUrl() + "/reflect_post.html"};
+    Url urlPost{server->GetBaseUrl() + "/post_reflect.html"};
     Url urlPut{server->GetBaseUrl() + "/put.html"};
     Session session;
     for (size_t i = 0; i < 3; ++i) {

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -659,65 +659,102 @@ TEST(CookiesTests, BasicCookiesTest) {
     Url url{server->GetBaseUrl() + "/basic_cookies.html"};
     Session session{};
     session.SetUrl(url);
-    Cookies cookies;
-
-    {
-        Response response = session.Get();
-        std::string expected_text{"Hello world!"};
-        EXPECT_EQ(expected_text, response.text);
-        EXPECT_EQ(url, response.url);
-        EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
-        EXPECT_EQ(200, response.status_code);
-        EXPECT_EQ(ErrorCode::OK, response.error.code);
-        cookies = response.cookies;
-    }
-    {
-        cookies["hello"] = "world";
-        cookies["my"] = "another; fake=cookie;"; // This is url encoded
-        session.SetCookies(cookies);
-        Response response = session.Get();
-        std::string expected_text{"Hello world!"};
-        EXPECT_EQ(expected_text, response.text);
-        EXPECT_EQ(url, response.url);
-        EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
-        EXPECT_EQ(200, response.status_code);
-        EXPECT_EQ(ErrorCode::OK, response.error.code);
-        EXPECT_EQ(cookies["cookie"], response.cookies["cookie"]);
-        EXPECT_EQ(cookies["icecream"], response.cookies["icecream"]);
-        EXPECT_EQ(cookies["expires"], response.cookies["expires"]);
+    Response response = session.Get();
+    Cookies res_cookies{response.cookies};
+    std::string expected_text{"Basic Cookies"};
+    cpr::Cookies expectedCookies{
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, 3905119080},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, 3905119080},
+    };
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+    EXPECT_EQ(expected_text, response.text);
+    for (auto cookie = res_cookies.begin(), expectedCookie = expectedCookies.begin(); cookie != res_cookies.end() && expectedCookie != expectedCookies.end(); cookie++, expectedCookie++) {
+        EXPECT_EQ(expectedCookie->GetName(), cookie->GetName());
+        EXPECT_EQ(expectedCookie->GetValue(), cookie->GetValue());
+        EXPECT_EQ(expectedCookie->GetDomain(), cookie->GetDomain());
+        EXPECT_EQ(expectedCookie->IsIncludingSubdomains(), cookie->IsIncludingSubdomains());
+        EXPECT_EQ(expectedCookie->GetPath(), cookie->GetPath());
+        EXPECT_EQ(expectedCookie->IsHttpsOnly(), cookie->IsHttpsOnly());
+        EXPECT_EQ(expectedCookie->GetExpires(), cookie->GetExpires());
     }
 }
 
-TEST(CookiesTests, CookiesConstructorTest) {
-    Url url{server->GetBaseUrl() + "/basic_cookies.html"};
-    Session session{};
-    session.SetUrl(url);
-    Cookies cookies;
-
+TEST(CookiesTests, ClientSetCookiesTest) {
+    Url url{server->GetBaseUrl() + "/cookies_reflect.html"};
     {
+        Session session{};
+        session.SetUrl(url);
+        session.SetCookies(Cookies{
+                {"SID", "31d4d96e407aad42"},
+                {"lang", "en-US"},
+        });
         Response response = session.Get();
-        std::string expected_text{"Hello world!"};
-        EXPECT_EQ(expected_text, response.text);
-        EXPECT_EQ(url, response.url);
+        std::string expected_text{"SID=31d4d96e407aad42; lang=en-US;"};
         EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
         EXPECT_EQ(200, response.status_code);
         EXPECT_EQ(ErrorCode::OK, response.error.code);
-        cookies = response.cookies;
+        EXPECT_EQ(expected_text, response.text);
     }
     {
-        cookies = Cookies{{"hello", "world"}, {"my", "another; fake=cookie;"}};
-        session.SetCookies(cookies);
+        Session session{};
+        session.SetUrl(url);
+        Cookies cookie{
+                {"SID", "31d4d96e407aad42"},
+                {"lang", "en-US"},
+        };
+        session.SetCookies(cookie);
         Response response = session.Get();
-        std::string expected_text{"Hello world!"};
-        EXPECT_EQ(expected_text, response.text);
-        EXPECT_EQ(url, response.url);
+        std::string expected_text{"SID=31d4d96e407aad42; lang=en-US;"};
         EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
         EXPECT_EQ(200, response.status_code);
         EXPECT_EQ(ErrorCode::OK, response.error.code);
-        cookies = response.cookies;
-        EXPECT_EQ(cookies["cookie"], response.cookies["cookie"]);
-        EXPECT_EQ(cookies["icecream"], response.cookies["icecream"]);
-        EXPECT_EQ(cookies["expires"], response.cookies["expires"]);
+        EXPECT_EQ(expected_text, response.text);
+    }
+}
+
+TEST(CookiesTests, RedirectionWithChangingCookiesTest) {
+    Url url{server->GetBaseUrl() + "/redirection_with_changing_cookies.html"};
+    {
+        Session session{};
+        session.SetUrl(url);
+        session.SetCookies(Cookies{
+                {"SID", "31d4d96e407aad42"},
+                {"lang", "en-US"},
+        });
+        session.SetRedirect(Redirect(0L));
+        Response response = session.Get();
+        std::string expected_text{"Received cookies are: SID=31d4d96e407aad42; lang=en-US;"};
+        EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+        EXPECT_EQ(200, response.status_code);
+        EXPECT_EQ(ErrorCode::OK, response.error.code);
+        EXPECT_EQ(expected_text, response.text);
+    }
+    {
+        Session session{};
+        session.SetUrl(url);
+        session.SetRedirect(Redirect(1L));
+        Response response = session.Get();
+        std::string expected_text{"Received cookies are: lang=en-US; SID=31d4d96e407aad42"};
+        EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+        EXPECT_EQ(200, response.status_code);
+        EXPECT_EQ(ErrorCode::OK, response.error.code);
+        EXPECT_EQ(expected_text, response.text);
+    }
+    {
+        Session session{};
+        session.SetUrl(url);
+        session.SetCookies(Cookies{
+                {"SID", "empty_sid"},
+        });
+        session.SetRedirect(Redirect(1L));
+        Response response = session.Get();
+        std::string expected_text{"Received cookies are: lang=en-US; SID=31d4d96e407aad42; SID=empty_sid;"};
+        EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+        EXPECT_EQ(200, response.status_code);
+        EXPECT_EQ(ErrorCode::OK, response.error.code);
+        EXPECT_EQ(expected_text, response.text);
     }
 }
 
@@ -851,7 +888,7 @@ TEST(DifferentMethodTests, MultipleGetPostTest) {
 
 TEST(DifferentMethodTests, MultipleDeleteHeadPutGetPostTest) {
     Url url{server->GetBaseUrl() + "/header_reflect.html"};
-    Url urlPost{server->GetBaseUrl() + "/reflect_post.html"};
+    Url urlPost{server->GetBaseUrl() + "/post_reflect.html"};
     Url urlPut{server->GetBaseUrl() + "/put.html"};
     Session session;
     for (size_t i = 0; i < 10; ++i) {

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -663,8 +663,8 @@ TEST(CookiesTests, BasicCookiesTest) {
     Cookies res_cookies{response.cookies};
     std::string expected_text{"Basic Cookies"};
     cpr::Cookies expectedCookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, 3905119080},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, 3905119080},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
     };
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(200, response.status_code);

--- a/test/util_tests.cpp
+++ b/test/util_tests.cpp
@@ -8,7 +8,7 @@
 using namespace cpr;
 
 TEST(UtilParseCookiesTests, BasicParseTest) {
-    Cookies expectedCookies{{Cookie("status", "on", "127.0.0.1", false, "/", false, 1656908640), Cookie("name", "debug", "127.0.0.1", false, "/", false, 0)}};
+    Cookies expectedCookies{{Cookie("status", "on", "127.0.0.1", false, "/", false, std::chrono::system_clock::from_time_t(1656908640)), Cookie("name", "debug", "127.0.0.1", false, "/", false, std::chrono::system_clock::from_time_t(0))}};
     curl_slist* raw_cookies = new curl_slist{
             (char*) "127.0.0.1\tFALSE\t/\tFALSE\t1656908640\tstatus\ton",
             new curl_slist{

--- a/test/util_tests.cpp
+++ b/test/util_tests.cpp
@@ -7,6 +7,29 @@
 
 using namespace cpr;
 
+TEST(UtilParseCookiesTests, BasicParseTest) {
+    Cookies expectedCookies{{Cookie("status", "on", "127.0.0.1", false, "/", false, 1656908640), Cookie("name", "debug", "127.0.0.1", false, "/", false, 0)}};
+    curl_slist* raw_cookies = new curl_slist{
+            (char*) "127.0.0.1\tFALSE\t/\tFALSE\t1656908640\tstatus\ton",
+            new curl_slist{
+                    (char*) "127.0.0.1\tFALSE\t/\tFALSE\t0\tname\tdebug",
+                    nullptr,
+            },
+    };
+    Cookies cookies = util::parseCookies(raw_cookies);
+    for (auto cookie = cookies.begin(), expectedCookie = expectedCookies.begin(); cookie != cookies.end() && expectedCookie != expectedCookies.end(); cookie++, expectedCookie++) {
+        EXPECT_EQ(expectedCookie->GetName(), cookie->GetName());
+        EXPECT_EQ(expectedCookie->GetValue(), cookie->GetValue());
+        EXPECT_EQ(expectedCookie->GetDomain(), cookie->GetDomain());
+        EXPECT_EQ(expectedCookie->IsIncludingSubdomains(), cookie->IsIncludingSubdomains());
+        EXPECT_EQ(expectedCookie->GetPath(), cookie->GetPath());
+        EXPECT_EQ(expectedCookie->IsHttpsOnly(), cookie->IsHttpsOnly());
+        EXPECT_EQ(expectedCookie->GetExpires(), cookie->GetExpires());
+    }
+    delete raw_cookies->next;
+    delete raw_cookies;
+}
+
 TEST(UtilParseHeaderTests, BasicParseTest) {
     std::string header_string{
             "HTTP/1.1 200 OK\r\n"
@@ -170,6 +193,42 @@ TEST(UtilSecureStringClearTests, NotEmptyStringTest) {
     std::string input = "Hello World!";
     util::secureStringClear(input);
     EXPECT_TRUE(input.empty());
+}
+
+TEST(UtilIsTrueTests, TrueTest) {
+    {
+        std::string input = "TRUE";
+        bool output = util::isTrue(input);
+        EXPECT_TRUE(output);
+    }
+    {
+        std::string input = "True";
+        bool output = util::isTrue(input);
+        EXPECT_TRUE(output);
+    }
+    {
+        std::string input = "true";
+        bool output = util::isTrue(input);
+        EXPECT_TRUE(output);
+    }
+}
+
+TEST(UtilIsTrueTests, FalseTest) {
+    {
+        std::string input = "FALSE";
+        bool output = util::isTrue(input);
+        EXPECT_FALSE(output);
+    }
+    {
+        std::string input = "False";
+        bool output = util::isTrue(input);
+        EXPECT_FALSE(output);
+    }
+    {
+        std::string input = "false";
+        bool output = util::isTrue(input);
+        EXPECT_FALSE(output);
+    }
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Issue

- #158 
- #777 

## Changes

- [x] Improved Cookies
- [X] Refactored Unit Tests

### Improved Cookies

Now the cookies received from a server could be easily accessed like:

```cpp
cpr::Response response = cpr::Get(url);
cpr::Cookies cookies{response.cookies};
for(auto cookie : cookies) {
    std::cout << cookie->GetName() << ":" << cookie->GetValue() << std::endl;
}
```

In addition to the cookie name and the value, you could also get the domain, path, expires, and so on:

```cpp
class Cookie {
  public:
    // skip constructors
    const std::string GetDomain() const;
    bool IsIncludingSubdomains() const;
    const std::string GetPath() const;
    bool IsHttpsOnly() const;
    const std::chrono::time_point<std::chrono::system_clock> GetExpires() const;
    const std::string GetExpiresString();
    const std::string GetName() const;
    const std::string GetValue() const;
}
```

If you would like to set cookies from the client-side, you can use the original interface just like the old implementations: 

```cpp
cpr::Session session{};
session.SetUrl(url);
session.SetCookies(cpr::Cookies{
        {"SID", "31d4d96e407aad42"},
        {"lang", "en-US"},
});
cpr::Response response = session.Get();
```

## Refactored Unit Tests

I corrected and simplified all unit tests concerning cookies. 
Here I only remained 2 mock server-side APIs for receiving normal and empty cookies: 

- OnRequestBasicCookies()
- OnRequestEmptyCookies()

Furthermore, I added another 2 APIs for reflecting `cpr::SetCookies` from the client-side and redirecting HTTP request according to cookies status: 

- OnRequestCookiesReflect()
- OnRequestRedirectionWithChangingCookies()

With the 2 APIs above, I rewrote all unit tests about `cpr::Session::SetCookie` and added new unit tests for HTTP redirection under the situation of changing cookies. 