### PR TITLE
Fix certificate information extraction from the response (#769)

### DIFF
--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -1,29 +1,30 @@
 cmake_minimum_required(VERSION 3.15)
 
 add_library(cpr
-    accept_encoding.cpp
-    async.cpp
-    auth.cpp
-    bearer.cpp
-    cookies.cpp
-    cprtypes.cpp
-    curl_container.cpp
-    curlholder.cpp
-    error.cpp
-    multipart.cpp
-    parameters.cpp
-    payload.cpp
-    proxies.cpp
-    proxyauth.cpp
-    session.cpp
-    threadpool.cpp
-    timeout.cpp
-    unix_socket.cpp
-    util.cpp
-    response.cpp
-    redirect.cpp
-    interceptor.cpp
-    ssl_ctx.cpp)
+        accept_encoding.cpp
+        async.cpp
+        auth.cpp
+        bearer.cpp
+        cert_info.cpp
+        cookies.cpp
+        cprtypes.cpp
+        curl_container.cpp
+        curlholder.cpp
+        error.cpp
+        multipart.cpp
+        parameters.cpp
+        payload.cpp
+        proxies.cpp
+        proxyauth.cpp
+        session.cpp
+        threadpool.cpp
+        timeout.cpp
+        unix_socket.cpp
+        util.cpp
+        response.cpp
+        redirect.cpp
+        interceptor.cpp
+        ssl_ctx.cpp)
 
 add_library(cpr::cpr ALIAS cpr)
 
@@ -37,44 +38,44 @@ endif()
 
 # Set version for shared libraries.
 set_target_properties(cpr
-     PROPERTIES
-     VERSION ${${PROJECT_NAME}_VERSION}
-     SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR})
+        PROPERTIES
+        VERSION ${${PROJECT_NAME}_VERSION}
+        SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR})
 
 # Import GNU common install directory variables
 include(GNUInstallDirs)
 
 if(CPR_FORCE_USE_SYSTEM_CURL)
-    install(TARGETS cpr
-            EXPORT cprTargets
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        install(TARGETS cpr
+                EXPORT cprTargets
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-    # Include CMake helpers for package config files
-    # Follow this installation guideline: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html
-    include(CMakePackageConfigHelpers)
+        # Include CMake helpers for package config files
+        # Follow this installation guideline: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html
+        include(CMakePackageConfigHelpers)
 
-    write_basic_package_version_file(
-            "${PROJECT_BINARY_DIR}/cpr/cprConfigVersion.cmake"
-            VERSION ${${PROJECT_NAME}_VERSION}
-            COMPATIBILITY ExactVersion)
+        write_basic_package_version_file(
+                "${PROJECT_BINARY_DIR}/cpr/cprConfigVersion.cmake"
+                VERSION ${${PROJECT_NAME}_VERSION}
+                COMPATIBILITY ExactVersion)
 
-    configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/cprConfig.cmake.in
-                                  "${PROJECT_BINARY_DIR}/cpr/cprConfig.cmake"
-                                  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cpr)
+        configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/cprConfig.cmake.in
+                "${PROJECT_BINARY_DIR}/cpr/cprConfig.cmake"
+                INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cpr)
 
-    install(EXPORT cprTargets
-            FILE cprTargets.cmake
-            NAMESPACE cpr::
-	    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cpr)
+        install(EXPORT cprTargets
+                FILE cprTargets.cmake
+                NAMESPACE cpr::
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cpr)
 
-    install(FILES ${PROJECT_BINARY_DIR}/cpr/cprConfig.cmake
-            ${PROJECT_BINARY_DIR}/cpr/cprConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cpr)
-     
+        install(FILES ${PROJECT_BINARY_DIR}/cpr/cprConfig.cmake
+                ${PROJECT_BINARY_DIR}/cpr/cprConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cpr)
+
 else()
-    install(TARGETS cpr
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        install(TARGETS cpr
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()

--- a/cpr/cert_info.cpp
+++ b/cpr/cert_info.cpp
@@ -1,0 +1,43 @@
+#include "cpr/cert_info.h"
+
+namespace cpr {
+
+std::string& CertInfo::operator[](const size_t& pos) {
+    return cert_info_[pos];
+}
+
+CertInfo::iterator CertInfo::begin() {
+    return cert_info_.begin();
+}
+CertInfo::iterator CertInfo::end() {
+    return cert_info_.end();
+}
+
+CertInfo::const_iterator CertInfo::begin() const {
+    return cert_info_.begin();
+}
+
+CertInfo::const_iterator CertInfo::end() const {
+    return cert_info_.end();
+}
+
+CertInfo::const_iterator CertInfo::cbegin() const {
+    return cert_info_.cbegin();
+}
+
+CertInfo::const_iterator CertInfo::cend() const {
+    return cert_info_.cend();
+}
+
+void CertInfo::emplace_back(const std::string& str) {
+    cert_info_.emplace_back(str);
+}
+
+void CertInfo::push_back(const std::string& str) {
+    cert_info_.push_back(str);
+}
+
+void CertInfo::pop_back() {
+    cert_info_.pop_back();
+}
+} // namespace cpr

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(cpr PRIVATE
     cpr/bearer.h
     cpr/body.h
     cpr/buffer.h
+    cpr/cert_info.h
     cpr/cookies.h
     cpr/cpr.h
     cpr/cprtypes.h

--- a/include/cpr/cert_info.h
+++ b/include/cpr/cert_info.h
@@ -1,0 +1,35 @@
+#ifndef CPR_CERT_INFO_H
+#define CPR_CERT_INFO_H
+
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+namespace cpr {
+
+class CertInfo {
+  private:
+    std::vector<std::string> cert_info_;
+
+  public:
+    CertInfo() = default;
+    CertInfo(const std::initializer_list<std::string>& entry) : cert_info_{entry} {};
+    ~CertInfo() noexcept = default;
+
+    using iterator = std::vector<std::string>::iterator;
+    using const_iterator = std::vector<std::string>::const_iterator;
+
+    std::string& operator[](const size_t& pos);
+    iterator begin();
+    iterator end();
+    const_iterator begin() const;
+    const_iterator end() const;
+    const_iterator cbegin() const;
+    const_iterator cend() const;
+    void emplace_back(const std::string& str);
+    void push_back(const std::string& str);
+    void pop_back();
+};
+} // namespace cpr
+
+#endif

--- a/include/cpr/cpr.h
+++ b/include/cpr/cpr.h
@@ -5,6 +5,7 @@
 #include "cpr/auth.h"
 #include "cpr/bearer.h"
 #include "cpr/callback.h"
+#include "cpr/cert_info.h"
 #include "cpr/connect_timeout.h"
 #include "cpr/cookies.h"
 #include "cpr/cprtypes.h"

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "cpr/cert_info.h"
 #include "cpr/cookies.h"
 #include "cpr/cprtypes.h"
 #include "cpr/error.h"
@@ -41,7 +42,7 @@ class Response {
 
     Response() = default;
     Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text, std::string&& p_header_string, Cookies&& p_cookies, Error&& p_error);
-    std::vector<std::string> GetCertInfo();
+    std::vector<CertInfo> GetCertInfos();
     Response(const Response& other) = default;
     Response(Response&& old) noexcept = default;
     ~Response() noexcept = default;

--- a/test/ssl_tests.cpp
+++ b/test/ssl_tests.cpp
@@ -58,7 +58,7 @@ TEST(SslTests, HelloWorldTestFull) {
     EXPECT_EQ(ErrorCode::OK, response.error.code) << response.error.message;
 }
 
-TEST(SslTests, GetCertInfo) {
+TEST(SslTests, GetCertInfos) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     Url url{server->GetBaseUrl() + "/hello.html"};
@@ -67,18 +67,50 @@ TEST(SslTests, GetCertInfo) {
     std::string keyPath{baseDirPath + "keys/"};
 
     SslOptions sslOpts = Ssl(ssl::CaPath{crtPath + "root-ca.crt"}, ssl::CertFile{crtPath + "client.crt"}, ssl::KeyFile{keyPath + "client.key"}, ssl::VerifyPeer{false}, ssl::VerifyHost{false}, ssl::VerifyStatus{false});
+
     Response response = cpr::Get(url, sslOpts, Timeout{5000}, Verbose{});
+    std::vector<CertInfo> certInfos = response.GetCertInfos();
+
     std::string expected_text = "Hello world!";
+    std::vector<CertInfo> expectedCertInfos{
+            CertInfo{
+                    "Subject:CN = test-server",
+                    "Issuer:C = GB, O = Example, CN = Root CA",
+                    "Version:2",
+                    "Serial Number:28c252871ec62a626a98006b0bf2888f",
+                    "Signature Algorithm:ED25519",
+                    "Public Key Algorithm:ED25519",
+                    "X509v3 Subject Alternative Name:DNS:localhost, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1",
+                    "X509v3 Subject Key Identifier:39:C1:81:38:01:DC:55:38:E5:2F:4E:7A:D0:4C:84:7B:B7:27:D3:AF",
+                    "X509v3 Authority Key Identifier:keyid:E4:F2:F3:85:0E:B7:85:75:84:76:E3:43:D1:B6:9D:14:B8:E2:A4:B7\n",
+                    "Start date:Jun 29 11:33:07 2022 GMT",
+                    "Expire date:Jun 28 11:33:07 2027 GMT",
+                    "Signature:2e:0d:a1:0d:f5:90:77:e9:eb:84:7d:80:63:63:4d:8a:eb:d9:23:57:1f:21:2a:ed:81:b4:a8:58:b9:00:1b:cb:5c:90:1b:33:6b:f6:ec:42:20:63:54:d6:60:ee:37:14:1b:1c:95:0b:33:ea:67:29:d4:cc:d9:7e:34:fd:47:04:",
+                    R"(Cert:-----BEGIN CERTIFICATE-----
+MIIBdTCCASegAwIBAgIQKMJShx7GKmJqmABrC/KIjzAFBgMrZXAwMTELMAkGA1UE
+BhMCR0IxEDAOBgNVBAoMB0V4YW1wbGUxEDAOBgNVBAMMB1Jvb3QgQ0EwHhcNMjIw
+NjI5MTEzMzA3WhcNMjcwNjI4MTEzMzA3WjAWMRQwEgYDVQQDDAt0ZXN0LXNlcnZl
+cjAqMAUGAytlcAMhAI64JU5RjfdEG1KQMxS5DQWkiGlKIQO7ye4mNFq9QleTo3Aw
+bjAsBgNVHREEJTAjgglsb2NhbGhvc3SHBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEw
+HQYDVR0OBBYEFDnBgTgB3FU45S9OetBMhHu3J9OvMB8GA1UdIwQYMBaAFOTy84UO
+t4V1hHbjQ9G2nRS44qS3MAUGAytlcANBAC4NoQ31kHfp64R9gGNjTYrr2SNXHyEq
+7YG0qFi5ABvLXJAbM2v27EIgY1TWYO43FBsclQsz6mcp1MzZfjT9RwQ=
+-----END CERTIFICATE-----
+)",
+            },
+    };
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code) << response.error.message;
-
-    std::vector<std::string> certInfo = response.GetCertInfo();
-    EXPECT_EQ(certInfo.size(), 1);
-    std::string expected_certInfo = "Subject:CN = test-server";
-    EXPECT_EQ(certInfo[0], expected_certInfo);
+    EXPECT_EQ(1, certInfos.size());
+    for (auto certInfo_it = certInfos.begin(), expectedCertInfo_it = expectedCertInfos.begin(); certInfo_it != certInfos.end() && expectedCertInfo_it != expectedCertInfos.end(); certInfo_it++, expectedCertInfo_it++) {
+        for (auto entry_it = (*certInfo_it).begin(), expectedEntry_it = (*expectedCertInfo_it).begin(); entry_it != (*certInfo_it).end() && expectedEntry_it != (*expectedCertInfo_it).end(); entry_it++, expectedEntry_it++) {
+            EXPECT_EQ(*expectedEntry_it, *entry_it);
+        }
+        std::cout << std::endl;
+    }
 }
 
 #if SUPPORT_CURLOPT_SSL_CTX_FUNCTION


### PR DESCRIPTION
## Issue

- #769

## Changes

- [X] Add a new class `cpr::CertInfo`
- [X] Rename the `std::vector<std::string> Response::GetCertInfo()` to `std::vector<CertInfo> Response::GetCertInfos()` and rewrite it
- [X] Rename the unit test `SslTests.GetCertInfo` to `SslTests.GetCertInfos` and rewrite it

## New Class: `cpr::CertInfo`

`cpr::CertInfo` is a class of a vector of `std::string`, and the string vector stores kinds of information about a certificate: 

```cpp
class CertInfo {
  private:
    std::vector<std::string> cert_info_;

  public:
    CertInfo() = default;
    CertInfo(const std::initializer_list<std::string>& entry) : cert_info_{entry} {};
    ~CertInfo() noexcept = default;

    using iterator = std::vector<std::string>::iterator;
    using const_iterator = std::vector<std::string>::const_iterator;

    std::string& operator[](const size_t& pos);
    iterator begin();
    iterator end();
    const_iterator begin() const;
    const_iterator end() const;
    const_iterator cbegin() const;
    const_iterator cend() const;
    void emplace_back(const std::string& __x);
    void push_back(const std::string& __x);
    void pop_back();
};
```

## Fixed Method: `std::vector<CertInfo> Response::GetCertInfos()` 

The original method is named `std::vector<std::string> Response::GetCertInfo()`; however, the name does not match its expected behavior. 
This renamed method is fixed according to the correct usage in the doc of `libcurl` - [CURLINFO_CERTINFO](https://curl.se/libcurl/c/CURLINFO_CERTINFO.html) - and you could simply iterate the  `certInfos` like that: 

```cpp
......
Response response = cpr::Get(url, sslOpts, Timeout{5000}, Verbose{});

std::vector<CertInfo> certInfos = response.GetCertInfos();
for (const auto& certinfo : certInfos) {
    for (const auto& entry : certinfo) {
        std::cout << entry << ", ";
    }
}
```

## Unit Test: `SslTests.GetCertInfos`

To make the unit test resonable, I created the expected variant `expectedCertInfos` for assertion just like the following example: 

```cpp
std::vector<CertInfo> expectedCertInfos{
        CertInfo{
                "Subject:CN = test-server",
                "Issuer:C = GB, O = Example, CN = Root CA",
                "Version:2",
                "Serial Number:28c252871ec62a626a98006b0bf2888f",
                "Signature Algorithm:ED25519",
                "Public Key Algorithm:ED25519",
                "X509v3 Subject Alternative Name:DNS:localhost, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1",
                "X509v3 Subject Key Identifier:39:C1:81:38:01:DC:55:38:E5:2F:4E:7A:D0:4C:84:7B:B7:27:D3:AF",
                "X509v3 Authority Key Identifier:keyid:E4:F2:F3:85:0E:B7:85:75:84:76:E3:43:D1:B6:9D:14:B8:E2:A4:B7\n",
                "Start date:Jun 29 11:33:07 2022 GMT",
                "Expire date:Jun 28 11:33:07 2027 GMT",
                "Signature:2e:0d:a1:0d:f5:90:77:e9:eb:84:7d:80:63:63:4d:8a:eb:d9:23:57:1f:21:2a:ed:81:b4:a8:58:b9:00:1b:cb:5c:90:1b:33:6b:f6:ec:42:20:63:54:d6:60:ee:37:14:1b:1c:95:0b:33:ea:67:29:d4:cc:d9:7e:34:fd:47:04:",
                R"(Cert:-----BEGIN CERTIFICATE-----
MIIBdTCCASegAwIBAgIQKMJShx7GKmJqmABrC/KIjzAFBgMrZXAwMTELMAkGA1UE
BhMCR0IxEDAOBgNVBAoMB0V4YW1wbGUxEDAOBgNVBAMMB1Jvb3QgQ0EwHhcNMjIw
NjI5MTEzMzA3WhcNMjcwNjI4MTEzMzA3WjAWMRQwEgYDVQQDDAt0ZXN0LXNlcnZl
cjAqMAUGAytlcAMhAI64JU5RjfdEG1KQMxS5DQWkiGlKIQO7ye4mNFq9QleTo3Aw
bjAsBgNVHREEJTAjgglsb2NhbGhvc3SHBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEw
HQYDVR0OBBYEFDnBgTgB3FU45S9OetBMhHu3J9OvMB8GA1UdIwQYMBaAFOTy84UO
t4V1hHbjQ9G2nRS44qS3MAUGAytlcANBAC4NoQ31kHfp64R9gGNjTYrr2SNXHyEq
7YG0qFi5ABvLXJAbM2v27EIgY1TWYO43FBsclQsz6mcp1MzZfjT9RwQ=
-----END CERTIFICATE-----
)",
        },
};
```
