### PR TITLE
Fixed #780 - Ubuntu 16 not supported any more - explicit_bzero

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,7 +26,12 @@ Checks: '*,
 -hicpp-signed-bitwise,
 -llvmlibc-implementation-in-namespace,
 -llvmlibc-restrict-system-libc-headers,
--readability-function-cognitive-complexity
+-readability-function-cognitive-complexity,
+-readability-identifier-length,
+-altera-unroll-loops,
+-altera-id-dependent-backward-branch,
+-bugprone-easily-swappable-parameters,
+-modernize-return-braced-init-list
 '
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'src/*.hpp'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,7 +458,7 @@ jobs:
         cxx: clang++
         run-test: true
         ctest-options: -V
-        configure-options: -DBUILD_SHARED_LIBS=ON -DCPR_BUILD_TESTS=ON -DCPR_BUILD_TESTS_SSL=ON
+        configure-options: -DBUILD_SHARED_LIBS=ON
 
   macos-clang-static-openssl:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,7 +458,7 @@ jobs:
         cxx: clang++
         run-test: true
         ctest-options: -V
-        configure-options: -DBUILD_SHARED_LIBS=ON
+        configure-options: -DBUILD_SHARED_LIBS=ON -DCPR_BUILD_TESTS=ON -DCPR_BUILD_TESTS_SSL=ON
 
   macos-clang-static-openssl:
     runs-on: macos-latest

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -5,7 +5,14 @@ on: [push, pull_request]
 jobs:
   clang-format:
     runs-on: ubuntu-latest
+    container: fedora:latest
     steps:
+    - name: Update package list
+      run: sudo dnf update -y
+    - name: Install dependencies
+      run: sudo dnf install -y openssl-devel cmake git gcc clang ninja-build
+    - name: Install clang-tidy
+      run: sudo dnf install -y clang-tools-extra
     - name: Checkout
       uses: actions/checkout@v3
     - name: Check format

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -5,17 +5,16 @@ on: [push, pull_request]
 jobs:
   clang-tidy:
     runs-on: ubuntu-latest
+    container: fedora:latest
     steps:
+    - name: Update package list
+      run: sudo dnf update -y
+    - name: Install dependencies
+      run: sudo dnf install -y openssl-devel cmake git gcc clang ninja-build
+    - name: Install clang-tidy
+      run: sudo dnf install -y clang-tools-extra
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Update package list
-      run: sudo apt update
-    - name: Install libssl-dev
-      run: sudo apt install libssl-dev
-    - name: Install clang-tidy
-      run: sudo apt install clang-tidy
     - name: "[Release g++] Build & Test"
       env:
         CPR_BUILD_TESTS: ON

--- a/cpr/async.cpp
+++ b/cpr/async.cpp
@@ -2,6 +2,7 @@
 
 namespace cpr {
 
+// NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
 CPR_SINGLETON_IMPL(GlobalThreadPool)
 
 } // namespace cpr

--- a/cpr/curlholder.cpp
+++ b/cpr/curlholder.cpp
@@ -11,6 +11,7 @@ CurlHolder::CurlHolder() {
      * https://curl.haxx.se/libcurl/c/threadsafe.html
      **/
     curl_easy_init_mutex_().lock();
+    // NOLINTNEXTLINE (cppcoreguidelines-prefer-member-initializer) since we need it to happen inside the lock
     handle = curl_easy_init();
     curl_easy_init_mutex_().unlock();
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -484,6 +484,7 @@ void Session::SetSslOptions(const SslOptions& options) {
     } else if (!options.key_blob.empty()) {
         std::string key_blob(options.key_blob);
         curl_blob blob{};
+        // NOLINTNEXTLINE (readability-container-data-pointer)
         blob.data = &key_blob[0];
         blob.len = key_blob.length();
         curl_easy_setopt(curl_->handle, CURLOPT_SSLKEY_BLOB, &blob);

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -15,6 +15,7 @@
 #include <Windows.h>
 #else
 // https://en.cppreference.com/w/c/string/byte/memset
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, cppcoreguidelines-macro-usage)
 #define __STDC_WANT_LIB_EXT1__ 1
 #include <cstring>
 #endif
@@ -132,7 +133,7 @@ int progressUserFunction(const ProgressCallback* progress, curl_off_t dltotal, c
 }
 
 int debugUserFunction(CURL* /*handle*/, curl_infotype type, char* data, size_t size, const DebugCallback* debug) {
-    (*debug)(DebugCallback::InfoType(type), std::string(data, size));
+    (*debug)(static_cast<DebugCallback::InfoType>(type), std::string(data, size));
     return 0;
 }
 

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -167,20 +167,22 @@ std::string urlDecode(const std::string& s) {
     return holder.urlDecode(s);
 }
 
-/**
- * Override the content of the provided string to hide sensitve data. The
- * string content after invocation is undefined. The string size is reset to zero.
- * impl. based on:
- * https://github.com/ojeda/secure_clear/blob/master/example-implementation/secure_clear.h
- **/
+#if defined(__STDC_LIB_EXT1__)
 void secureStringClear(std::string& s) {
     if (s.empty()) {
         return;
     }
-#if defined(__STDC_LIB_EXT1__)
     memset_s(&s.front(), s.length(), 0, s.length());
+    s.clear();
+}
 #elif defined(_WIN32)
+void secureStringClear(std::string& s) {
+    if (s.empty()) {
+        return;
+    }
     SecureZeroMemory(&s.front(), s.length());
+    s.clear();
+}
 #else
 #if defined(__clang__)
 #pragma clang optimize off // clang
@@ -188,16 +190,20 @@ void secureStringClear(std::string& s) {
 #pragma GCC push_options   // g++
 #pragma GCC optimize("O0") // g++
 #endif
+void secureStringClear(std::string& s) {
+    if (s.empty()) {
+        return;
+    }
+    // NOLINTNEXTLINE (readability-container-data-pointer)
     char* ptr = &(s[0]);
     memset(ptr, '\0', s.length());
-#if defined(__clang__)
-#pragma clang optimize on  // clang
-#elif defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW32__) || defined(__MINGW64__)
-#pragma GCC pop_options    // g++
-#endif
-#endif
-s.clear();
-    
+    s.clear();
 }
+#if defined(__clang__)
+#pragma clang optimize on // clang
+#elif defined(__GNUC__) || defined(__MINGW32__) || defined(__MINGW32__) || defined(__MINGW64__)
+#pragma GCC pop_options // g++
+#endif
+#endif
 } // namespace util
 } // namespace cpr

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -29,6 +29,13 @@ int debugUserFunction(CURL* handle, curl_infotype type, char* data, size_t size,
 std::vector<std::string> split(const std::string& to_split, char delimiter);
 std::string urlEncode(const std::string& s);
 std::string urlDecode(const std::string& s);
+
+/**
+ * Override the content of the provided string to hide sensitive data. The
+ * string content after invocation is undefined. The string size is reset to zero.
+ * impl. based on:
+ * https://github.com/ojeda/secure_clear/blob/master/example-implementation/secure_clear.h
+ **/
 void secureStringClear(std::string& s);
 } // namespace util
 } // namespace cpr


### PR DESCRIPTION
Fixed #780 

Builds on top of: https://github.com/libcpr/cpr/pull/783

Also fixes clang-tidy and clang-format linting now running inside a docker image, so we lint/format with an more up to date version.