### PR TITLE
Add support of uploading multiple files within the same multipart field (#563)

### DIFF
--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(cpr
         curl_container.cpp
         curlholder.cpp
         error.cpp
+        file.cpp
         multipart.cpp
         parameters.cpp
         payload.cpp

--- a/cpr/file.cpp
+++ b/cpr/file.cpp
@@ -1,0 +1,40 @@
+#include "cpr/file.h"
+
+namespace cpr {
+
+Files::iterator Files::begin() {
+    return files.begin();
+}
+
+Files::iterator Files::end() {
+    return files.end();
+}
+
+Files::const_iterator Files::begin() const {
+    return files.begin();
+}
+
+Files::const_iterator Files::end() const {
+    return files.end();
+}
+
+Files::const_iterator Files::cbegin() const {
+    return files.cbegin();
+}
+
+Files::const_iterator Files::cend() const {
+    return files.cend();
+}
+
+void Files::emplace_back(const File& file) {
+    files.emplace_back(file);
+}
+
+void Files::push_back(const File& file) {
+    files.push_back(file);
+}
+
+void Files::pop_back() {
+    files.pop_back();
+}
+} // namespace cpr

--- a/include/cpr/file.h
+++ b/include/cpr/file.h
@@ -1,16 +1,53 @@
 #ifndef CPR_FILE_H
 #define CPR_FILE_H
 
+#include <initializer_list>
 #include <string>
+#include <vector>
 
 #include <cpr/filesystem.h>
 
 namespace cpr {
 
 struct File {
-    explicit File(fs::path&& p_filepath) : filepath(std::move(p_filepath)) {}
-    explicit File(const fs::path& p_filepath) : filepath(p_filepath) {}
-    const fs::path filepath;
+    explicit File(std::string&& p_filepath, const std::string& p_overrided_filename = {}) : filepath(std::move(p_filepath)), overrided_filename(p_overrided_filename) {}
+    explicit File(const std::string& p_filepath, const std::string& p_overrided_filename = {}) : filepath(p_filepath), overrided_filename(p_overrided_filename) {}
+
+    const std::string filepath;
+    const std::string overrided_filename;
+
+    bool hasOverridedFilename() const noexcept {
+        return !overrided_filename.empty();
+    };
+};
+
+class Files {
+  public:
+    Files() = default;
+    Files(const File& p_file) : files{p_file} {};
+    Files(const std::initializer_list<File>& p_files) : files{p_files} {};
+    Files(const std::initializer_list<std::string>& p_filepaths) {
+        for (const std::string& filepath : p_filepaths) {
+            files.emplace_back(File(filepath));
+        }
+    };
+    ~Files() noexcept = default;
+
+    using iterator = std::vector<File>::iterator;
+    using const_iterator = std::vector<File>::const_iterator;
+
+    iterator begin();
+    iterator end();
+    const_iterator begin() const;
+    const_iterator end() const;
+    const_iterator cbegin() const;
+    const_iterator cend() const;
+    void emplace_back(const File& file);
+    void push_back(const File& file);
+    void pop_back();
+
+  private:
+    std::vector<File> files;
 };
 
 } // namespace cpr

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -13,15 +13,14 @@
 namespace cpr {
 
 struct Part {
-    Part(const std::string& p_name, const std::string& p_value, const std::string& p_content_type = {}) : name{p_name}, value{p_value}, content_type{p_content_type}, is_file{false}, is_buffer{false}, has_filename{false} {}
-    Part(const std::string& p_name, const std::int32_t& p_value, const std::string& p_content_type = {}) : name{p_name}, value{std::to_string(p_value)}, content_type{p_content_type}, is_file{false}, is_buffer{false}, has_filename{false} {}
-    Part(const std::string& p_name, const File& file, const std::string& p_content_type = {}) : name{p_name}, value{file.filepath.string()}, content_type{p_content_type}, is_file{true}, is_buffer{false}, has_filename{false} {}
-    Part(const std::string& p_name, const fs::path& p_filename, const File& file, const std::string& p_content_type = {}) : name{p_name}, filename{p_filename.string()}, value{file.filepath.string()}, content_type{p_content_type}, is_file{true}, is_buffer{false}, has_filename{true} {}
-    Part(const std::string& p_name, const Buffer& buffer, const std::string& p_content_type = {}) : name{p_name}, value{buffer.filename.string()}, content_type{p_content_type}, data{buffer.data}, datalen{buffer.datalen}, is_file{false}, is_buffer{true}, has_filename{false} {}
+    Part(const std::string& p_name, const std::string& p_value, const std::string& p_content_type = {}) : name{p_name}, value{p_value}, content_type{p_content_type}, is_file{false}, is_buffer{false} {}
+    Part(const std::string& p_name, const std::int32_t& p_value, const std::string& p_content_type = {}) : name{p_name}, value{std::to_string(p_value)}, content_type{p_content_type}, is_file{false}, is_buffer{false} {}
+    Part(const std::string& p_name, const Files& p_files, const std::string& p_content_type = {}) : name{p_name}, value{}, content_type{p_content_type}, is_file{true}, is_buffer{false}, files{p_files} {}
+    Part(const std::string& p_name, Files&& p_files, const std::string& p_content_type = {}) : name{p_name}, value{}, content_type{p_content_type}, is_file{true}, is_buffer{false}, files{std::move(p_files)} {}
+    Part(const std::string& p_name, const Buffer& buffer, const std::string& p_content_type = {}) : name{p_name}, value{buffer.filename.string()}, content_type{p_content_type}, data{buffer.data}, datalen{buffer.datalen}, is_file{false}, is_buffer{true} {}
 
     std::string name;
     // We don't use fs::path here, as this leads to problems using windows
-    std::string filename;
     std::string value;
     std::string content_type;
     Buffer::data_t data{nullptr};
@@ -30,7 +29,8 @@ struct Part {
     long datalen{0};
     bool is_file;
     bool is_buffer;
-    bool has_filename;
+
+    Files files;
 };
 
 class Multipart {

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -406,47 +406,21 @@ void HttpServer::OnRequestFormPost(mg_connection* conn, http_message* msg) {
     size_t chunk_len = 0;
     size_t n1 = 0;
     size_t n2 = 0;
-    std::map<std::string, std::string> forms;
-    std::map<std::string, std::string> filenames;
-
-    while ((n2 = mg_parse_multipart(msg->body.p + n1, msg->body.len - n1, var_name, sizeof(var_name), file_name, sizeof(file_name), &chunk, &chunk_len)) > 0) {
-        n1 += n2;
-        forms[var_name] = std::string(chunk, chunk_len);
-        filenames[var_name] = std::string(file_name);
-    }
 
     std::string headers = "Content-Type: application/json";
-    std::string response;
-    if (forms.find("y") == forms.end()) {
-        if (!filenames["x"].empty()) {
-            response = std::string{
-                    "{\n"
-                    "  \"x\": " +
-                    filenames["x"] + "=" + forms["x"] +
-                    "\n"
-                    "}"};
-        } else {
-            response = std::string{
-                    "{\n"
-                    "  \"x\": " +
-                    forms["x"] +
-                    "\n"
-                    "}"};
+    std::string response{""};
+    response += "{\n";
+    while ((n2 = mg_parse_multipart(msg->body.p + n1, msg->body.len - n1, var_name, sizeof(var_name), file_name, sizeof(file_name), &chunk, &chunk_len)) > 0) {
+        n1 += n2;
+        response += "  \"" + std::string(var_name) + "\": \"";
+        if (!std::string(file_name).empty()) {
+            response += std::string(file_name) + "=";
         }
-    } else {
-        response = std::string{
-                "{\n"
-                "  \"x\": " +
-                forms["x"] +
-                ",\n"
-                "  \"y\": " +
-                forms["y"] +
-                ",\n"
-                "  \"sum\": " +
-                std::to_string(atoi(forms["x"].c_str()) + atoi(forms["y"].c_str())) +
-                "\n"
-                "}"};
+        response += std::string(chunk, chunk_len) + "\",\n";
     }
+    response.erase(response.find_last_not_of(",\n") + 1);
+    response += "\n}";
+
     mg_send_head(conn, 201, response.length(), headers.c_str());
     mg_send(conn, response.c_str(), response.length());
 }

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -589,7 +589,7 @@ TEST(MultipartTests, SetMultipartTest) {
     Response response = session.Post();
     std::string expected_text{
             "{\n"
-            "  \"x\": 5\n"
+            "  \"x\": \"5\"\n"
             "}"};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
@@ -607,7 +607,7 @@ TEST(MultipartTests, SetMultipartValueTest) {
     Response response = session.Post();
     std::string expected_text{
             "{\n"
-            "  \"x\": 5\n"
+            "  \"x\": \"5\"\n"
             "}"};
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);


### PR DESCRIPTION
## Issue

- #563 

## Concept

Uploading multiple files in the same multipart field is feasible using `curl`, `Postman`, and `Insomnia`. 
A sample command is like: 

```shell
$ curl \
    --request POST \
    <url> \
    --form "files=@/path/to/file1" \
    --form "files=@/path/to/file2"
```

The followings are the references I read: 

- [Curl form upload multiple files - Dark Launch](https://www.darklaunch.com/curl-form-upload-multiple-files.html)
- [Postman - Uploading multiple files through a multipart/form-data POST](https://bartwullems.blogspot.com/2021/02/postman-uploading-multiple-files.html)
- [[Question] Upload multiple Multipart files in one parameter · Issue #1659 · Kong/insomnia](https://github.com/Kong/insomnia/issues/1659)

## Changes

- [X] New class `cpr::Files` for `cpr::Multipart`
- [X] Using `Files` for the initialization of `cpr::Multipart`
- [X] Update and refactor `cpr::Session::SetMultipart()` to setup multiple files
- [x] Add and refactor the mock HTTP server and unit tests

### New class `Files` for `Multipart`

Users could define a single file or multiple files easily using `cpr::File` and `cpr::Files`: 

```cpp
cpr::File singleFile("file1");
cpr::File singleFileWithOverridedFilename("file1", "applefile");
cpr::Files multipleFiles{"file1", "file2"};
cpr::Files multipleFilesWithOverridedFilename{
        File{"file1", "applefile"},
        File{"file1", "bananafile"},
};
```

### Using `Files` for the initialization of `Multipart`

With the additional class `Files`, now users could define the `Multipart` more conveniently: 

```cpp
cpr::Session session;
session.SetMultipart{{"files", singleFile}}
session.SetMultipart{{"files", singleFileWithOverridedFilename}}
session.SetMultipart{{"files", multipleFiles}}
session.SetMultipart{{"files", multipleFilesWithOverridedFilename}}
```

Of course, you could also use the `rvalue` of `File` or `Files` as an argument of `cpr::Session::SetMultipart`: 

```cpp
cpr::Session session;
session.SetMultipart{{"files", File{"file1"}}}
session.SetMultipart{{"files", File{"file1", "applefile"}}}
session.SetMultipart{{"files", Files{"file1", "file2"}}}
session.SetMultipart{{"files", Files{
                                       File{"file1", "applefile"},
                                       File{"file2", "bananafile"},
                               }}}
```

### Update and refactor `cpr::Session::SetMultipart()` to setup multiple files

In `cpr::Session::SetMultipart`, there are three categories: file, buffer, and common value. In order to set up multiple files in a multipart, a loop is needed: 

```cpp
void Session::SetMultipart() {
    // Skip......
    for (const Part& part : multipart.parts) {
        // Skip......
        if (part.is_file) {
            for (const File& file : part.files) {
                formdata.push_back({CURLFORM_COPYNAME, part.name.c_str()});
                formdata.push_back({CURLFORM_FILE, file.filepath.string().c_str()});
                if (file.hasOverridedFilename()) {
                    formdata.push_back({CURLFORM_FILENAME, file.overrided_filename.c_str()});
                }
                formdata.push_back({CURLFORM_END, nullptr});
                curl_formadd(&formpost, &lastptr, CURLFORM_ARRAY, formdata.data(), CURLFORM_END);
                formdata.clear();
            }
        } 
        // Skip......
    }
    // Skip......
}
```

### Add and refactor the mock HTTP server and unit tests

The method `OnRequestFormPost` of the mock HTTP server was not convenient and too limited if developers want to have more kinds of unit testing. Therefore, I modified it and other unit tests concerned. 

For example, if I issue an HTTP request with multipart containing: 

```json
{
  "files": {
    "filename": "file1",
    "content": "apple"
  },
  "files": {
    "filename": "file2",
    "content": "banana"
  },
}
```

Then the response text will be: 

```json
{
  "files": "file1=apple",
  "files": "file2=banana"
}
```

Finally, I added two unit tests: `UrlEncodedPostTests.FormPostMultipleFilesTestLvalue` and `UrlEncodedPostTests.FormPostMultipleFilesTestRvalue` to test the usages I described above. 