### PR TITLE
Disable the header "Expect: 100-continue" by default (#293)

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -61,6 +61,13 @@ void Session::SetHeaderInternal() {
         }
     }
 
+    // libcurl would prepare the header "Expect: 100-continue" by default when uploading files larger than 1 MB.
+    // Here we would like to disable this feature:
+    curl_slist* temp = curl_slist_append(chunk, "Expect:");
+    if (temp) {
+        chunk = temp;
+    }
+
     curl_easy_setopt(curl_->handle, CURLOPT_HTTPHEADER, chunk);
 
     curl_slist_free_all(curl_->chunk);

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -754,6 +754,22 @@ void HttpServer::OnRequestCheckAcceptEncoding(mg_connection* conn, http_message*
     mg_send(conn, response.c_str(), response.length());
 }
 
+void HttpServer::OnRequestCheckExpect100Continue(mg_connection* conn, http_message* msg) {
+    std::string response;
+    for (size_t i = 0; i < sizeof(msg->header_names) / sizeof(mg_str); i++) {
+        if (!msg->header_names[i].p) {
+            continue;
+        }
+        std::string name = std::string(msg->header_names[i].p, msg->header_names[i].len);
+        if (std::string{"Expect"} == name) {
+            response = std::string(msg->header_values[i].p, msg->header_values[i].len);
+        }
+    }
+    std::string headers = "Content-Type: text/html";
+    mg_send_head(conn, 200, response.length(), headers.c_str());
+    mg_send(conn, response.c_str(), response.length());
+}
+
 void HttpServer::OnRequest(mg_connection* conn, http_message* msg) {
     std::string uri = std::string(msg->uri.p, msg->uri.len);
     if (uri == "/") {
@@ -820,6 +836,8 @@ void HttpServer::OnRequest(mg_connection* conn, http_message* msg) {
         OnRequestLocalPort(conn, msg);
     } else if (uri == "/check_accept_encoding.html") {
         OnRequestCheckAcceptEncoding(conn, msg);
+    } else if (uri == "/check_expect_100_continue.html") {
+        OnRequestCheckExpect100Continue(conn, msg);
     } else {
         OnRequestNotFound(conn, msg);
     }

--- a/test/httpServer.hpp
+++ b/test/httpServer.hpp
@@ -52,6 +52,7 @@ class HttpServer : public AbstractServer {
     static void OnRequestDownloadGzip(mg_connection* conn, http_message* msg);
     static void OnRequestLocalPort(mg_connection* conn, http_message* msg);
     static void OnRequestCheckAcceptEncoding(mg_connection* conn, http_message* msg);
+    static void OnRequestCheckExpect100Continue(mg_connection* conn, http_message* msg);
 
   protected:
     mg_connection* initServer(mg_mgr* mgr, MG_CB(mg_event_handler_t event_handler, void* user_data)) override;

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -1147,6 +1147,25 @@ TEST(BasicTests, AcceptEncodingTestWithCostomizedStringLValue) {
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 
+TEST(BasicTests, DisableHeaderExpect100ContinueTest) {
+    Url url{server->GetBaseUrl() + "/check_expect_100_continue.html"};
+    std::string filename{"test_file"};
+    std::string content{std::string(1024 * 1024, 'a')};
+    std::ofstream test_file;
+    test_file.open(filename);
+    test_file << content;
+    test_file.close();
+    Session session{};
+    session.SetUrl(url);
+    session.SetMultipart({{"file", File{"test_file"}}});
+    Response response = session.Post();
+    std::string expected_text{""};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 TEST(AsyncRequestsTests, AsyncGetTest) {
     Url url{server->GetBaseUrl() + "/hello.html"};
     std::shared_ptr<Session> session = std::make_shared<Session>();
@@ -1426,7 +1445,6 @@ TEST(CallbackTests, PatchCallbackTest) {
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
-
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Issue

- #293 

## Description

When you send a POST using `curl`, there will be a header "Expect: 100-continue" added if the file size is larger than 1 MB. 
The mechanism is aiming to reduce the cost if the server wants to deny the transmission of the data before it has been transmitted. 

Here are some nice references if you want to check them out: 

- [Curl: Time to disable "Expect: 100-continue" by default?](https://curl.se/mail/lib-2017-07/0013.html)
- [Expect 100-continue - Everything curl](https://everything.curl.dev/http/post/expect100)
- [When curl sends 100-continue | Georg's Log](https://gms.tf/when-curl-sends-100-continue.html)

## Changes

- [X] Set the default header to "Expect:" in the method Session::SetHeaderInternal()
- [X] A new mock HTTP server method and unit test