### PR TITLE
Support to build only cpr (alone) as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ macro(cpr_option OPTION_NAME OPTION_TEXT OPTION_DEFAULT)
     message(STATUS "  ${OPTION_NAME}: ${${OPTION_NAME}}")
 endmacro()
 
-option(BUILD_SHARED_LIBS "Build libraries as shared libraries" ON)
 message(STATUS "C++ Requests CMake Options")
 message(STATUS "=======================================================")
 cpr_option(CPR_GENERATE_COVERAGE "Set to ON to generate coverage reports." OFF)


### PR DESCRIPTION
Instead of the global BUILD_SHARED_LIBS option, a private CPR_SHARED_LIB option is used.

Signed-off-by: Matthias Klein <matthias@extraklein.de>