### PR TITLE
Fixed thread pool not creating enough new threads

### DIFF
--- a/include/cpr/async.h
+++ b/include/cpr/async.h
@@ -9,8 +9,10 @@ namespace cpr {
 class GlobalThreadPool : public ThreadPool {
     CPR_SINGLETON_DECL(GlobalThreadPool)
   protected:
-    GlobalThreadPool() : ThreadPool() {}
-    ~GlobalThreadPool() {}
+    GlobalThreadPool() = default;
+
+  public:
+    ~GlobalThreadPool() override = default;
 };
 
 /**
@@ -19,18 +21,18 @@ class GlobalThreadPool : public ThreadPool {
  * async(std::bind(&Class::mem_fn, &obj))
  * async(std::mem_fn(&Class::mem_fn, &obj))
  **/
-template<class Fn, class... Args>
+template <class Fn, class... Args>
 auto async(Fn&& fn, Args&&... args) -> std::future<decltype(fn(args...))> {
     return GlobalThreadPool::GetInstance()->Submit(std::forward<Fn>(fn), std::forward<Args>(args)...);
 }
 
 class async {
   public:
-    static void startup(size_t min_threads = CPR_DEFAULT_THREAD_POOL_MIN_THREAD_NUM,
-                 size_t max_threads = CPR_DEFAULT_THREAD_POOL_MAX_THREAD_NUM,
-                 std::chrono::milliseconds max_idle_ms = CPR_DEFAULT_THREAD_POOL_MAX_IDLE_TIME) {
+    static void startup(size_t min_threads = CPR_DEFAULT_THREAD_POOL_MIN_THREAD_NUM, size_t max_threads = CPR_DEFAULT_THREAD_POOL_MAX_THREAD_NUM, std::chrono::milliseconds max_idle_ms = CPR_DEFAULT_THREAD_POOL_MAX_IDLE_TIME) {
         GlobalThreadPool* gtp = GlobalThreadPool::GetInstance();
-        if (gtp->IsStarted()) return;
+        if (gtp->IsStarted()) {
+            return;
+        }
         gtp->SetMinThreadNum(min_threads);
         gtp->SetMaxThreadNum(max_threads);
         gtp->SetMaxIdleTime(max_idle_ms);

--- a/include/cpr/threadpool.h
+++ b/include/cpr/threadpool.h
@@ -15,7 +15,7 @@
 
 #define CPR_DEFAULT_THREAD_POOL_MAX_THREAD_NUM std::thread::hardware_concurrency()
 
-constexpr size_t CPR_DEFAULT_THREAD_POOL_MIN_THREAD_NUM  = 1;
+constexpr size_t CPR_DEFAULT_THREAD_POOL_MIN_THREAD_NUM = 1;
 constexpr std::chrono::milliseconds CPR_DEFAULT_THREAD_POOL_MAX_IDLE_TIME{60000};
 
 namespace cpr {
@@ -24,9 +24,7 @@ class ThreadPool {
   public:
     using Task = std::function<void()>;
 
-    ThreadPool( size_t min_threads = CPR_DEFAULT_THREAD_POOL_MIN_THREAD_NUM,
-                size_t max_threads = CPR_DEFAULT_THREAD_POOL_MAX_THREAD_NUM,
-                std::chrono::milliseconds max_idle_ms = CPR_DEFAULT_THREAD_POOL_MAX_IDLE_TIME );
+    explicit ThreadPool(size_t min_threads = CPR_DEFAULT_THREAD_POOL_MIN_THREAD_NUM, size_t max_threads = CPR_DEFAULT_THREAD_POOL_MAX_THREAD_NUM, std::chrono::milliseconds max_idle_ms = CPR_DEFAULT_THREAD_POOL_MAX_IDLE_TIME);
 
     virtual ~ThreadPool();
 
@@ -64,21 +62,20 @@ class ThreadPool {
      * Submit(std::bind(&Class::mem_fn, &obj))
      * Submit(std::mem_fn(&Class::mem_fn, &obj))
      **/
-    template<class Fn, class... Args>
+    template <class Fn, class... Args>
     auto Submit(Fn&& fn, Args&&... args) -> std::future<decltype(fn(args...))> {
-        if (status == STOP) { Start(); }
-        if (idle_thread_num == 0 && cur_thread_num < max_thread_num) {
+        if (status == STOP) {
+            Start();
+        }
+        if (idle_thread_num <= 0 && cur_thread_num < max_thread_num) {
             CreateThread();
         }
         using RetType = decltype(fn(args...));
-        auto task = std::make_shared<std::packaged_task<RetType()> >(
-            std::bind(std::forward<Fn>(fn), std::forward<Args>(args)...));
+        auto task = std::make_shared<std::packaged_task<RetType()> >(std::bind(std::forward<Fn>(fn), std::forward<Args>(args)...));
         std::future<RetType> future = task->get_future();
         {
             std::lock_guard<std::mutex> locker(task_mutex);
-            tasks.emplace([task]{
-                (*task)();
-            });
+            tasks.emplace([task] { (*task)(); });
         }
 
         task_cond.notify_one();
@@ -101,20 +98,22 @@ class ThreadPool {
         RUNNING,
         PAUSE,
     };
+
     struct ThreadData {
         std::shared_ptr<std::thread> thread;
         std::thread::id id;
-        Status          status;
-        time_t          start_time;
-        time_t          stop_time;
-    };
-    std::atomic<Status>     status;
-    std::atomic<size_t>     cur_thread_num;
-    std::atomic<size_t>     idle_thread_num;
-    std::list<ThreadData>   threads;
-    std::mutex              thread_mutex;
-    std::queue<Task>        tasks;
-    std::mutex              task_mutex;
+        Status status;
+        time_t start_time;
+        time_t stop_time;
+    } __attribute__((aligned(64)));
+
+    std::atomic<Status> status;
+    std::atomic<size_t> cur_thread_num;
+    std::atomic<size_t> idle_thread_num;
+    std::list<ThreadData> threads;
+    std::mutex thread_mutex;
+    std::queue<Task> tasks;
+    std::mutex task_mutex;
     std::condition_variable task_cond;
 };
 


### PR DESCRIPTION
In case one would call GetCallback(...) to fast behind each other,
this would result in not enough threads being created.
This is caused by the threads not having enough time to start and
decrement the idle_thread_num.
Now this number is decremented initially.

An example for how to trigger this bug is:
```c++
#include <future>
#include <iostream>
#include <string>
#include <vector>
#include <cpr/cpr.h>

int main(int /*argc*/, char** /*argv*/) {
    std::vector<std::future<void>> futs;
    for (size_t i = 0; i < 10; i++) {
        futs.emplace_back(cpr::GetCallback(
            [i](cpr::Response /*res*/) {
                std::cout << "Done: " << i << '\n';
            },
            cpr::Url{"http://www.httpbin.org/get"}));
    }

    for (const std::future<void>& f : futs) {
        f.wait();
    }
    return 0;
}
```

Fixes #800 