### PR TITLE
Fix iOS check for skipping CA bundle search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,8 +239,6 @@ else()
 
         if(NOT DEFINED CURL_CA_BUNDLE)
             set(CURL_CA_BUNDLE "auto" CACHE INTERNAL "")
-        elseif(CPR_SKIP_CA_BUNDLE_SEARCH)
-            set(CURL_CA_BUNDLE "none" CACHE INTERNAL "")
         endif()
 
         if(SSL_BACKEND_USED STREQUAL "WinSSL")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,9 @@ else()
             set(CURL_CA_PATH "auto" CACHE INTERNAL "")
         endif()
 
-        if(NOT DEFINED CURL_CA_BUNDLE)
+        if(CPR_SKIP_CA_BUNDLE_SEARCH)
+            set(CURL_CA_BUNDLE "none" CACHE INTERNAL "")
+        elseif(NOT DEFINED CURL_CA_BUNDLE)
             set(CURL_CA_BUNDLE "auto" CACHE INTERNAL "")
         endif()
 


### PR DESCRIPTION
This check is not working if the immediate flag above is not set, just check for it first before checking for the other value.