### PR TITLE
Enable ENABLE_DEBUG option when CMAKE_BUILD_TYPE is Debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ else()
         include(cmake/zlib_external.cmake)
     endif()
 
-    string( TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER )
+    string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER)
     if (BUILD_TYPE_LOWER STREQUAL "debug")
         message(STATUS "Enabled curl debug features")
         set(ENABLE_DEBUG ON CACHE INTERNAL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,12 @@ else()
         include(cmake/zlib_external.cmake)
     endif()
 
+    string( TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER )
+    if (BUILD_TYPE_LOWER STREQUAL "debug")
+        message(STATUS "Enabled curl debug features")
+        set(ENABLE_DEBUG ON CACHE INTERNAL "" FORCE)
+    endif()
+
     # We only need HTTP (and HTTPS) support:
     set(HTTP_ONLY ON CACHE INTERNAL "" FORCE)
     set(BUILD_CURL_EXE OFF CACHE INTERNAL "" FORCE)


### PR DESCRIPTION
This enables more verbose logging like:
STATE: DID => PERFORMING handle 0x56082ff9dd38; line 2218 (connection #0)

Signed-off-by: Matthias Klein <matthias@extraklein.de>