### PR TITLE
Add std::map based constructors to Proxies and ProxyAuthentication

### DIFF
--- a/cpr/proxies.cpp
+++ b/cpr/proxies.cpp
@@ -8,6 +8,7 @@
 namespace cpr {
 
 Proxies::Proxies(const std::initializer_list<std::pair<const std::string, std::string>>& hosts) : hosts_{hosts} {}
+Proxies::Proxies(const std::map<std::string, std::string>& hosts) : hosts_{hosts} {}
 
 bool Proxies::has(const std::string& protocol) const {
     return hosts_.count(protocol) > 0;

--- a/include/cpr/proxies.h
+++ b/include/cpr/proxies.h
@@ -10,6 +10,7 @@ class Proxies {
   public:
     Proxies() = default;
     Proxies(const std::initializer_list<std::pair<const std::string, std::string>>& hosts);
+    Proxies(const std::map<std::string, std::string>& hosts);
 
     bool has(const std::string& protocol) const;
     const std::string& operator[](const std::string& protocol);

--- a/include/cpr/proxyauth.h
+++ b/include/cpr/proxyauth.h
@@ -30,6 +30,7 @@ class ProxyAuthentication {
   public:
     ProxyAuthentication() = default;
     ProxyAuthentication(const std::initializer_list<std::pair<const std::string, EncodedAuthentication>>& auths) : proxyAuth_{auths} {}
+    ProxyAuthentication(const std::map<std::string, EncodedAuthentication>& auths) : proxyAuth_{auths} {}
 
     bool has(const std::string& protocol) const;
     const char* operator[](const std::string& protocol);


### PR DESCRIPTION
This PR extends Proxies and ProxyAuthentication classes with an extra constructor to be able to init with `std::map`, not just `std::initializer_list`.

In this way, the proxy can be initialized dynamically. It's not needed to write the proxy list in the code in advance.