### PR TITLE
File loading cleanup

### DIFF
--- a/include/cpr/body.h
+++ b/include/cpr/body.h
@@ -29,18 +29,17 @@ class Body : public StringHolder<Body> {
     Body(const Buffer& buffer) : StringHolder<Body>(reinterpret_cast<const char*>(buffer.data), static_cast<size_t>(buffer.datalen)) {}
     Body(const File& file) {
         std::ifstream is(file.filepath, std::ifstream::binary);
-        if (is) {
-            is.seekg(0, is.end);
-            int length = static_cast<int>(is.tellg());
-            is.seekg(0, is.beg);
-            std::vector<char> buffer;
-            buffer.resize(length);
-            is.read(&buffer[0], length);
-            is.close();
-            str_ = std::string(buffer.begin(), buffer.end());
-        } else {
+        if (!is) {
             throw std::invalid_argument("Can't open the file for HTTP request body!");
         }
+
+        is.seekg(0, std::ios::end);
+        const auto length = is.tellg();
+        is.seekg(0, std::ios::beg);
+        std::string buffer;
+        buffer.resize(static_cast<size_t>(length));
+        is.read(&buffer[0], length);
+        str_ = std::move(buffer);
     }
     Body(const Body& other) = default;
     Body(Body&& old) noexcept = default;

--- a/include/cpr/body.h
+++ b/include/cpr/body.h
@@ -34,7 +34,7 @@ class Body : public StringHolder<Body> {
         }
 
         is.seekg(0, std::ios::end);
-        const auto length = is.tellg();
+        const std::streampos length = is.tellg();
         is.seekg(0, std::ios::beg);
         std::string buffer;
         buffer.resize(static_cast<size_t>(length));


### PR DESCRIPTION
This change improves loading files:
* Uses `auto` (`std::streampos`) for the file position to support files bigger than 2^31 bytes
* No need to manually call `is.close()`
* Invert if to reduce nesting
* Avoids loading the file to a vector<char> to copy it to a string (load into a string directly)
 
Unfortunately `StringHolder` doesn't support loading into it directly (the string inside is private) so we still need to keep the intermediate string and move it, but it's still an improvement