### PR TITLE
Fixed compiler warnings

### DIFF
--- a/include/cpr/api.h
+++ b/include/cpr/api.h
@@ -247,13 +247,13 @@ template <typename... Ts>
 AsyncResponse DownloadAsync(fs::path local_path, Ts... ts) {
     return std::async(
             std::launch::async,
-            [](fs::path local_path, Ts... ts) {
+            [](fs::path local_path_, Ts... ts_) {
 #ifdef CPR_USE_BOOST_FILESYSTEM
-                std::ofstream f(local_path.string());
+                std::ofstream f(local_path_.string());
 #else
-                std::ofstream f(local_path);
+                std::ofstream f(local_path_);
 #endif
-                return Download(f, std::move(ts)...);
+                return Download(f, std::move(ts_)...);
             },
             std::move(local_path), std::move(ts)...);
 }

--- a/include/cpr/range.h
+++ b/include/cpr/range.h
@@ -17,8 +17,8 @@ class Range {
     std::int64_t finish_at;
 
     const std::string str() const {
-        std::string from_str = (resume_from < (std::int64_t) 0) ? "" : std::to_string(resume_from);
-        std::string to_str = (finish_at < (std::int64_t) 0) ? "" : std::to_string(finish_at);
+        std::string from_str = (resume_from < 0U) ? "" : std::to_string(resume_from);
+        std::string to_str = (finish_at < 0U) ? "" : std::to_string(finish_at);
         return from_str + "-" + to_str;
     }
 };


### PR DESCRIPTION
gcc 12.2.0 in c++20 yielded 2 warnings (for `-Wshadow`, `-Wold-style-cast`)
 - use of old-style cast
 - shadowing parameters
 
This MR attempts to eliminate those warnings.

PS: Thanks a lot for this project, I've used it in a good amount of my personal projects and it has never let me down.  
This is my first MR to this repository, I hope I didn't miss anything important.