### PR TITLE
Add instructions for building with Bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ find_package(cpr REQUIRED)
 add_executable(your_target_name your_target_name.cpp)
 target_link_libraries(your_target_name PRIVATE cpr::cpr)
 ```
+
+### Bazel
+
+Please refer to [hedronvision/bazel-make-cc-https-easy](https://github.com/hedronvision/bazel-make-cc-https-easy).
+
 ### Packages for Linux Distributions
 
 Alternatively, you may install a package specific to your Linux distribution. Since so few distributions currently have a package for cpr, most users will not be able to run your program with this approach.


### PR DESCRIPTION
Hey, @COM8!

I finally got those Bazel rules done and released. They make it easy to build libcpr, curl, and dependencies across macOS, Android, iOS, and the other Apple platforms, with Windows and Linux likely coming soon. 
(It's actually just libcurl that's the tricky one--the libcpr rules themselves should already work across platforms, build static and dynamic libs across a variety of compilers, etc.)

As in our discussion over in https://github.com/libcpr/cpr/issues/715#issuecomment-1231161216, the advantage of making CPR easy to use from Bazel is that there's a sizable C++ community there, including most of the highly resourced companies. I'm hoping we might be able to bring a lot more folks the magic of CPR, since there's otherwise no good HTTPS request library easily available from Bazel.

Anyway, I'm hoping you'd be down to take this PR, pointing Bazel users over to the BUILD files and instructions, just released. (From our earlier discussion, it sounded like you'd prefer to keep them external to avoid maintaining without in house Bazel expertise. Totally get it.) I'll manage keep this and the curl files up to date; we're actively using them. And I'll see how many Bazelers I can send your way!

Thanks for your consideration!
Chris

P.S. Btw, someday, Bazel might be useful to you guys for pumping out prebuilt libraries across platforms or running tests. Bazel's good at bundling and fast, incremental builds and tests. But that's for some other time.

