### PR TITLE
Fixed GetDownloadFileLength error

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -680,7 +680,11 @@ cpr_off_t Session::GetDownloadFileLength() {
     curl_easy_setopt(curl_->handle, CURLOPT_HTTPGET, 1);
     curl_easy_setopt(curl_->handle, CURLOPT_NOBODY, 1);
     if (DoEasyPerform() == CURLE_OK) {
-        curl_easy_getinfo(curl_->handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &downloadFileLenth);
+        long status_code{};
+        curl_easy_getinfo(curl_->handle, CURLINFO_RESPONSE_CODE, &status_code);
+        if (200 == status_code) {
+            curl_easy_getinfo(curl_->handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &downloadFileLenth);
+        }
     }
     return downloadFileLenth;
 }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -680,6 +680,7 @@ cpr_off_t Session::GetDownloadFileLength() {
     curl_easy_setopt(curl_->handle, CURLOPT_HTTPGET, 1);
     curl_easy_setopt(curl_->handle, CURLOPT_NOBODY, 1);
     if (DoEasyPerform() == CURLE_OK) {
+        // NOLINTNEXTLINE (google-runtime-int)
         long status_code{};
         curl_easy_getinfo(curl_->handle, CURLINFO_RESPONSE_CODE, &status_code);
         if (200 == status_code) {

--- a/test/download_tests.cpp
+++ b/test/download_tests.cpp
@@ -111,6 +111,26 @@ TEST(DownloadTests, RangeTestMultipleRangesOption) {
     EXPECT_EQ(download_size, response.downloaded_bytes);
 }
 
+bool real_write_data(std::string data, intptr_t userdata) {
+    std::string* dst = (std::string*) userdata;
+    *dst += data;
+    return true;
+}
+TEST(DownloadTests, GetDownloadFileLength) {
+    cpr::Url url{server->GetBaseUrl() + "/get_download_file_length.html"};
+    cpr::Session session;
+    session.SetUrl(url);
+    auto len = session.GetDownloadFileLength();
+    EXPECT_EQ(len, -1);
+
+    std::string strFileData;
+    cpr::Response response = session.Download(cpr::WriteCallback{real_write_data, (intptr_t) &strFileData});
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
+    EXPECT_EQ(strFileData, "this is a file content.");
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(server);

--- a/test/download_tests.cpp
+++ b/test/download_tests.cpp
@@ -112,7 +112,8 @@ TEST(DownloadTests, RangeTestMultipleRangesOption) {
 }
 
 bool real_write_data(std::string data, intptr_t userdata) {
-    std::string* dst = static_cast<std::string*>(userdata);
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+    std::string* dst = reinterpret_cast<std::string*>(userdata);
     *dst += data;
     return true;
 }

--- a/test/download_tests.cpp
+++ b/test/download_tests.cpp
@@ -112,10 +112,11 @@ TEST(DownloadTests, RangeTestMultipleRangesOption) {
 }
 
 bool real_write_data(std::string data, intptr_t userdata) {
-    std::string* dst = (std::string*) userdata;
+    std::string* dst = static_cast<std::string*>(userdata);
     *dst += data;
     return true;
 }
+
 TEST(DownloadTests, GetDownloadFileLength) {
     cpr::Url url{server->GetBaseUrl() + "/get_download_file_length.html"};
     cpr::Session session;

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -367,7 +367,7 @@ void HttpServer::OnRequestResolvePermRedirect(mg_connection* conn, mg_http_messa
         }
     }
 
-    if(location.empty()) {
+    if (location.empty()) {
         std::string errorMessage{"Redirect location missing"};
         SendError(conn, 405, errorMessage);
         return;
@@ -824,6 +824,17 @@ void HttpServer::OnRequestCheckExpect100Continue(mg_connection* conn, mg_http_me
     mg_http_reply(conn, 200, headers.c_str(), response.c_str());
 }
 
+void HttpServer::OnRequestGetDownloadFileLength(mg_connection* conn, mg_http_message* msg) {
+    auto method = std::string{msg->method.ptr, msg->method.len};
+    if (method == std::string{"HEAD"}) {
+        mg_http_reply(conn, 405, nullptr, "");
+    } else {
+        std::string response("this is a file content.");
+        std::string headers = "Content-Type: text/plain\r\n";
+        mg_http_reply(conn, 200, headers.c_str(), response.c_str());
+    }
+}
+
 void HttpServer::OnRequest(mg_connection* conn, mg_http_message* msg) {
     std::string uri = std::string(msg->uri.ptr, msg->uri.len);
     if (uri == "/") {
@@ -898,6 +909,8 @@ void HttpServer::OnRequest(mg_connection* conn, mg_http_message* msg) {
         OnRequestCheckAcceptEncoding(conn, msg);
     } else if (uri == "/check_expect_100_continue.html") {
         OnRequestCheckExpect100Continue(conn, msg);
+    } else if (uri == "/get_download_file_length.html") {
+        OnRequestGetDownloadFileLength(conn, msg);
     } else {
         OnRequestNotFound(conn, msg);
     }

--- a/test/httpServer.hpp
+++ b/test/httpServer.hpp
@@ -55,6 +55,7 @@ class HttpServer : public AbstractServer {
     static void OnRequestLocalPort(mg_connection* conn, mg_http_message* msg);
     static void OnRequestCheckAcceptEncoding(mg_connection* conn, mg_http_message* msg);
     static void OnRequestCheckExpect100Continue(mg_connection* conn, mg_http_message* msg);
+    static void OnRequestGetDownloadFileLength(mg_connection* conn, mg_http_message* msg);
 
   protected:
     mg_connection* initServer(mg_mgr* mgr, mg_event_handler_t event_handler) override;


### PR DESCRIPTION
Hi,

GetDownloadFileLength returns an incorrect length value when the server does not support the HEAD method for obtaining the file length. The reason is that it does not check the HTTP status code.
