### PR TITLE
API type tweaks

### DIFF
--- a/CppCheckSuppressions.txt
+++ b/CppCheckSuppressions.txt
@@ -1,2 +1,3 @@
 noExplicitConstructor
 ConfigurationNotChecked
+passedByValue

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -11,8 +11,7 @@ enum class AuthMode { BASIC, DIGEST, NTLM };
 
 class Authentication {
   public:
-    Authentication(const std::string& username, const std::string& password, const AuthMode& auth_mode) : auth_string_{username + ":" + password}, auth_mode_{auth_mode} {}
-    Authentication(std::string&& username, std::string&& password, AuthMode&& auth_mode) : auth_string_{std::move(username) + ":" + std::move(password)}, auth_mode_{std::move(auth_mode)} {}
+    Authentication(std::string username, std::string password, AuthMode auth_mode) : auth_string_{std::move(username) + ":" + std::move(password)}, auth_mode_{std::move(auth_mode)} {}
     Authentication(const Authentication& other) = default;
     Authentication(Authentication&& old) noexcept = default;
     ~Authentication() noexcept;

--- a/include/cpr/bearer.h
+++ b/include/cpr/bearer.h
@@ -14,9 +14,7 @@ namespace cpr {
 class Bearer {
   public:
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Bearer(const std::string& token) : token_string_{token} {}
-    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Bearer(std::string&& token) : token_string_{std::move(token)} {}
+    Bearer(std::string token) : token_string_{std::move(token)} {}
     Bearer(const Bearer& other) = default;
     Bearer(Bearer&& old) noexcept = default;
     virtual ~Bearer() noexcept;

--- a/include/cpr/body.h
+++ b/include/cpr/body.h
@@ -17,11 +17,9 @@ class Body : public StringHolder<Body> {
   public:
     Body() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Body(const std::string& body) : StringHolder<Body>(body) {}
+    Body(std::string body) : StringHolder<Body>(std::move(body)) {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Body(std::string&& body) : StringHolder<Body>(std::move(body)) {}
-    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Body(const std::string_view& body) : StringHolder<Body>(body) {}
+    Body(std::string_view body) : StringHolder<Body>(body) {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     Body(const char* body) : StringHolder<Body>(body) {}
     Body(const char* str, size_t len) : StringHolder<Body>(str, len) {}

--- a/include/cpr/cprtypes.h
+++ b/include/cpr/cprtypes.h
@@ -20,9 +20,8 @@ template <class T>
 class StringHolder {
   public:
     StringHolder() = default;
-    explicit StringHolder(const std::string& str) : str_(str) {}
-    explicit StringHolder(std::string&& str) : str_(std::move(str)) {}
-    explicit StringHolder(const std::string_view& str) : str_(str) {}
+    explicit StringHolder(std::string str) : str_(std::move(str)) {}
+    explicit StringHolder(std::string_view str) : str_(str) {}
     explicit StringHolder(const char* str) : str_(str) {}
     StringHolder(const char* str, size_t len) : str_(str, len) {}
     StringHolder(const std::initializer_list<std::string> args) {
@@ -109,11 +108,9 @@ class Url : public StringHolder<Url> {
   public:
     Url() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Url(const std::string& url) : StringHolder<Url>(url) {}
+    Url(std::string url) : StringHolder<Url>(std::move(url)) {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Url(std::string&& url) : StringHolder<Url>(std::move(url)) {}
-    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Url(const std::string_view& url) : StringHolder<Url>(url) {}
+    Url(std::string_view url) : StringHolder<Url>(url) {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     Url(const char* url) : StringHolder<Url>(url) {}
     Url(const char* str, size_t len) : StringHolder<Url>(std::string(str, len)) {}

--- a/include/cpr/curl_container.h
+++ b/include/cpr/curl_container.h
@@ -12,16 +12,14 @@
 namespace cpr {
 
 struct Parameter {
-    Parameter(const std::string& p_key, const std::string& p_value) : key{p_key}, value{p_value} {}
-    Parameter(std::string&& p_key, std::string&& p_value) : key{std::move(p_key)}, value{std::move(p_value)} {}
+    Parameter(std::string p_key, std::string p_value) : key{std::move(p_key)}, value{std::move(p_value)} {}
 
     std::string key;
     std::string value;
 };
 
 struct Pair {
-    Pair(const std::string& p_key, const std::string& p_value) : key(p_key), value(p_value) {}
-    Pair(std::string&& p_key, std::string&& p_value) : key(std::move(p_key)), value(std::move(p_value)) {}
+    Pair(std::string p_key, std::string p_value) : key(std::move(p_key)), value(std::move(p_value)) {}
 
     std::string key;
     std::string value;

--- a/include/cpr/file.h
+++ b/include/cpr/file.h
@@ -10,8 +10,7 @@
 namespace cpr {
 
 struct File {
-    explicit File(std::string&& p_filepath, const std::string& p_overrided_filename = {}) : filepath(std::move(p_filepath)), overrided_filename(p_overrided_filename) {}
-    explicit File(const std::string& p_filepath, const std::string& p_overrided_filename = {}) : filepath(p_filepath), overrided_filename(p_overrided_filename) {}
+    explicit File(std::string p_filepath, const std::string& p_overrided_filename = {}) : filepath(std::move(p_filepath)), overrided_filename(p_overrided_filename) {}
 
     const std::string filepath;
     const std::string overrided_filename;

--- a/include/cpr/interface.h
+++ b/include/cpr/interface.h
@@ -12,11 +12,9 @@ class Interface : public StringHolder<Interface> {
   public:
     Interface() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Interface(const std::string& iface) : StringHolder<Interface>(iface) {}
+    Interface(std::string iface) : StringHolder<Interface>(std::move(iface)) {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Interface(std::string&& iface) : StringHolder<Interface>(std::move(iface)) {}
-    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Interface(const std::string_view& iface) : StringHolder<Interface>(iface) {}
+    Interface(std::string_view iface) : StringHolder<Interface>(iface) {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     Interface(const char* iface) : StringHolder<Interface>(iface) {}
     Interface(const char* str, size_t len) : StringHolder<Interface>(str, len) {}

--- a/include/cpr/proxyauth.h
+++ b/include/cpr/proxyauth.h
@@ -11,8 +11,7 @@ namespace cpr {
 class EncodedAuthentication {
   public:
     EncodedAuthentication() : auth_string_{""} {}
-    EncodedAuthentication(const std::string& username, const std::string& password) : auth_string_{cpr::util::urlEncode(username) + ":" + cpr::util::urlEncode(password)} {}
-    EncodedAuthentication(std::string&& username, std::string&& password) : auth_string_{cpr::util::urlEncode(std::move(username)) + ":" + cpr::util::urlEncode(std::move(password))} {}
+    EncodedAuthentication(std::string username, std::string password) : auth_string_{cpr::util::urlEncode(std::move(username)) + ":" + cpr::util::urlEncode(std::move(password))} {}
     EncodedAuthentication(const EncodedAuthentication& other) = default;
     EncodedAuthentication(EncodedAuthentication&& old) noexcept = default;
     virtual ~EncodedAuthentication() noexcept;

--- a/include/cpr/unix_socket.h
+++ b/include/cpr/unix_socket.h
@@ -8,7 +8,7 @@ namespace cpr {
 class UnixSocket {
   public:
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    UnixSocket(std::string&& unix_socket) : unix_socket_(std::move(unix_socket)) {}
+    UnixSocket(std::string unix_socket) : unix_socket_(std::move(unix_socket)) {}
 
     const char* GetUnixSocketString() const noexcept;
 

--- a/include/cpr/user_agent.h
+++ b/include/cpr/user_agent.h
@@ -11,11 +11,9 @@ class UserAgent : public StringHolder<UserAgent> {
   public:
     UserAgent() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    UserAgent(const std::string& useragent) : StringHolder<UserAgent>(useragent) {}
+    UserAgent(std::string useragent) : StringHolder<UserAgent>(std::move(useragent)) {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    UserAgent(std::string&& useragent) : StringHolder<UserAgent>(std::move(useragent)) {}
-    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    UserAgent(const std::string_view& useragent) : StringHolder<UserAgent>(useragent) {}
+    UserAgent(std::string_view useragent) : StringHolder<UserAgent>(useragent) {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     UserAgent(const char* useragent) : StringHolder<UserAgent>(useragent) {}
     UserAgent(const char* str, size_t len) : StringHolder<UserAgent>(str, len) {}


### PR DESCRIPTION
- Use `std::string_view` instead of `const std::string_view&` as the type is trivially copyable
- Remove duplicates by replacing `const std::string&`and `std::string&&` with plain `std::string`