### PR TITLE
Mutiperform Intercept

### DIFF
--- a/cpr/interceptor.cpp
+++ b/cpr/interceptor.cpp
@@ -47,4 +47,7 @@ std::vector<Response> InterceptorMulti::proceed(MultiPerform& multi) {
     return multi.proceed();
 }
 
+void InterceptorMulti::PrepareDownloadSession(MultiPerform& multi, size_t sessions_index, const WriteCallback& write) {
+    multi.PrepareDownloadSessions(sessions_index, write);
+}
 } // namespace cpr

--- a/cpr/interceptor.cpp
+++ b/cpr/interceptor.cpp
@@ -25,7 +25,7 @@ Response Interceptor::proceed(Session& session, ProceedHttpMethod httpMethod) {
         case ProceedHttpMethod::PUT_REQUEST:
             return session.Put();
         default:
-            throw std::invalid_argument{"Can't procceed the session with the provided http method!"};
+            throw std::invalid_argument{"Can't proceed the session with the provided http method!"};
     }
 }
 
@@ -41,6 +41,10 @@ Response Interceptor::proceed(Session& session, ProceedHttpMethod httpMethod, co
         return session.Download(write);
     }
     throw std::invalid_argument{"WriteCallback argument is only valid for ProceedHttpMethod::DOWNLOAD_CALLBACK!"};
+}
+
+std::vector<Response> InterceptorMulti::proceed(MultiPerform& multi) {
+    return multi.proceed();
 }
 
 } // namespace cpr

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -67,6 +67,14 @@ void MultiPerform::RemoveSession(const std::shared_ptr<Session>& session) {
     }
 }
 
+std::vector<std::pair<std::shared_ptr<Session>, MultiPerform::HttpMethod>>& MultiPerform::GetSessions() {
+    return sessions_;
+}
+
+const std::vector<std::pair<std::shared_ptr<Session>, MultiPerform::HttpMethod>>& MultiPerform::GetSessions() const {
+    return sessions_;
+}
+
 void MultiPerform::DoMultiPerform() {
     // Do multi perform until every handle has finished
     int still_running{0};
@@ -137,6 +145,10 @@ std::vector<Response> MultiPerform::MakeRequest() {
 }
 
 std::vector<Response> MultiPerform::MakeDownloadRequest() {
+    if (!interceptors_.empty()) {
+        return intercept();
+    }
+
     DoMultiPerform();
     return ReadMultiInfo([](Session& session, CURLcode curl_error) -> Response { return session.CompleteDownload(curl_error); });
 }

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -294,10 +294,10 @@ std::vector<Response> MultiPerform::Perform() {
 std::vector<Response> MultiPerform::proceed() {
     // Check if this multiperform mixes download and non download requests
     if (!sessions_.empty()) {
-        bool new_is_download_multi_perform = sessions_.front().second == HttpMethod::DOWNLOAD_REQUEST;
+        const bool new_is_download_multi_perform = sessions_.front().second == HttpMethod::DOWNLOAD_REQUEST;
 
         for (const std::pair<std::shared_ptr<Session>, HttpMethod>& s : sessions_) {
-            HttpMethod method = s.second;
+            const HttpMethod method = s.second;
             if ((new_is_download_multi_perform && method != HttpMethod::DOWNLOAD_REQUEST) || (!new_is_download_multi_perform && method == HttpMethod::DOWNLOAD_REQUEST)) {
                 throw std::invalid_argument("Failed to proceed with session: Cannot mix download and non-download methods!");
             }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -104,9 +104,7 @@ Session::Session() : curl_(new CurlHolder()) {
 
 Response Session::makeDownloadRequest() {
     if (!interceptors_.empty()) {
-        const std::shared_ptr<Interceptor> interceptor = interceptors_.front();
-        interceptors_.pop();
-        return interceptor->intercept(*this);
+        return intercept();
     }
 
     const CURLcode curl_error = DoEasyPerform();
@@ -213,10 +211,7 @@ void Session::prepareCommonDownload() {
 
 Response Session::makeRequest() {
     if (!interceptors_.empty()) {
-        // At least one interceptor exists -> Execute its intercept function
-        const std::shared_ptr<Interceptor> interceptor = interceptors_.front();
-        interceptors_.pop();
-        return interceptor->intercept(*this);
+        intercept();
     }
 
     const CURLcode curl_error = DoEasyPerform();
@@ -915,6 +910,13 @@ void Session::AddInterceptor(const std::shared_ptr<Interceptor>& pinterceptor) {
 Response Session::proceed() {
     prepareCommon();
     return makeRequest();
+}
+
+Response Session::intercept() {
+    // At least one interceptor exists -> Execute its intercept function
+    const std::shared_ptr<Interceptor> interceptor = interceptors_.front();
+    interceptors_.pop();
+    return interceptor->intercept(*this);
 }
 
 // clang-format off

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -211,7 +211,7 @@ void Session::prepareCommonDownload() {
 
 Response Session::makeRequest() {
     if (!interceptors_.empty()) {
-        intercept();
+        return intercept();
     }
 
     const CURLcode curl_error = DoEasyPerform();

--- a/include/cpr/interceptor.h
+++ b/include/cpr/interceptor.h
@@ -64,6 +64,8 @@ class InterceptorMulti {
 
   protected:
     static std::vector<Response> proceed(MultiPerform& multi);
+
+    static void PrepareDownloadSession(MultiPerform& multi, size_t sessions_index, const WriteCallback& write);
 };
 
 } // namespace cpr

--- a/include/cpr/interceptor.h
+++ b/include/cpr/interceptor.h
@@ -1,11 +1,12 @@
 #ifndef CPR_INTERCEPTOR_H
 #define CPR_INTERCEPTOR_H
 
+#include "cpr/multiperform.h"
 #include "cpr/response.h"
 #include "cpr/session.h"
+#include <vector>
 
 namespace cpr {
-
 class Interceptor {
   public:
     enum class ProceedHttpMethod {
@@ -20,7 +21,14 @@ class Interceptor {
         DOWNLOAD_FILE_REQUEST,
     };
 
+    Interceptor() = default;
+    Interceptor(const Interceptor& other) = default;
+    Interceptor(Interceptor&& old) = default;
     virtual ~Interceptor() = default;
+
+    Interceptor& operator=(const Interceptor& other) = default;
+    Interceptor& operator=(Interceptor&& old) = default;
+
     virtual Response intercept(Session& session) = 0;
 
   protected:
@@ -28,6 +36,34 @@ class Interceptor {
     static Response proceed(Session& session, ProceedHttpMethod httpMethod);
     static Response proceed(Session& session, ProceedHttpMethod httpMethod, std::ofstream& file);
     static Response proceed(Session& session, ProceedHttpMethod httpMethod, const WriteCallback& write);
+};
+
+class InterceptorMulti {
+  public:
+    enum class ProceedHttpMethod {
+        GET_REQUEST = 0,
+        POST_REQUEST,
+        PUT_REQUEST,
+        DELETE_REQUEST,
+        PATCH_REQUEST,
+        HEAD_REQUEST,
+        OPTIONS_REQUEST,
+        DOWNLOAD_CALLBACK_REQUEST,
+        DOWNLOAD_FILE_REQUEST,
+    };
+
+    InterceptorMulti() = default;
+    InterceptorMulti(const InterceptorMulti& other) = default;
+    InterceptorMulti(InterceptorMulti&& old) = default;
+    virtual ~InterceptorMulti() = default;
+
+    InterceptorMulti& operator=(const InterceptorMulti& other) = default;
+    InterceptorMulti& operator=(InterceptorMulti&& old) = default;
+
+    virtual std::vector<Response> intercept(MultiPerform& multi) = 0;
+
+  protected:
+    static std::vector<Response> proceed(MultiPerform& multi);
 };
 
 } // namespace cpr

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -47,10 +47,15 @@ class MultiPerform {
 
     void AddSession(std::shared_ptr<Session>& session, HttpMethod method = HttpMethod::UNDEFINED);
     void RemoveSession(const std::shared_ptr<Session>& session);
+    std::vector<std::pair<std::shared_ptr<Session>, HttpMethod>>& GetSessions();
+    [[nodiscard]] const std::vector<std::pair<std::shared_ptr<Session>, HttpMethod>>& GetSessions() const;
 
     void AddInterceptor(const std::shared_ptr<InterceptorMulti>& pinterceptor);
 
   private:
+    // Interceptors should be able to call the private proceed() and PrepareDownloadSessions() functions
+    friend InterceptorMulti;
+
     void SetHttpMethod(HttpMethod method);
 
     void PrepareSessions();
@@ -83,8 +88,6 @@ class MultiPerform {
     std::unique_ptr<CurlMultiHolder> multicurl_;
     bool is_download_multi_perform{false};
 
-    // Interceptors should be able to call the private proceed() function
-    friend InterceptorMulti;
     std::queue<std::shared_ptr<InterceptorMulti>> interceptors_;
 };
 

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -29,7 +29,12 @@ class MultiPerform {
     };
 
     MultiPerform();
+    MultiPerform(const MultiPerform& other) = delete;
+    MultiPerform(MultiPerform&& old) = default;
     ~MultiPerform();
+
+    MultiPerform& operator=(const MultiPerform& other) = delete;
+    MultiPerform& operator=(MultiPerform&& old) noexcept = default;
 
     std::vector<Response> Get();
     std::vector<Response> Delete();

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -219,7 +219,7 @@ class Session : public std::enable_shared_from_this<Session> {
     void AddInterceptor(const std::shared_ptr<Interceptor>& pinterceptor);
 
   private:
-    // Interceptors should be able to call the private procceed() function
+    // Interceptors should be able to call the private proceed() function
     friend Interceptor;
     friend MultiPerform;
 
@@ -250,6 +250,7 @@ class Session : public std::enable_shared_from_this<Session> {
     Response makeDownloadRequest();
     Response makeRequest();
     Response proceed();
+    Response intercept();
     void prepareCommon();
     void prepareCommonDownload();
     void SetHeaderInternal();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,7 @@ add_cpr_test(encoded_auth)
 add_cpr_test(version)
 add_cpr_test(download)
 add_cpr_test(interceptor)
+add_cpr_test(interceptor_multi)
 add_cpr_test(multiperform)
 add_cpr_test(resolve)
 

--- a/test/interceptor_multi_tests.cpp
+++ b/test/interceptor_multi_tests.cpp
@@ -130,8 +130,8 @@ class ChangeRequestMethodToDownloadCallbackInterceptorMulti : public Interceptor
   public:
     std::vector<Response> intercept(MultiPerform& multi) override {
         EXPECT_FALSE(multi.GetSessions().empty());
-        PrepareDownloadSession(multi, 0, WriteCallback{write_data, 0});
         multi.GetSessions().front().second = MultiPerform::HttpMethod::DOWNLOAD_REQUEST;
+        PrepareDownloadSession(multi, 0, WriteCallback{write_data, 0});
         return proceed(multi);
     }
 };

--- a/test/interceptor_multi_tests.cpp
+++ b/test/interceptor_multi_tests.cpp
@@ -1,0 +1,450 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+
+#include "cpr/cpr.h"
+#include "cpr/interceptor.h"
+#include "cpr/response.h"
+#include "cpr/session.h"
+#include "httpServer.hpp"
+
+using namespace cpr;
+
+static HttpServer* server = new HttpServer();
+
+class HiddenHelloWorldRedirectInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        std::shared_ptr<Session> session = multi.GetSessions().front().first;
+
+        // Save original url
+        Url old_url = session->GetFullRequestUrl();
+
+        // Rewrite the url
+        Url url{server->GetBaseUrl() + "/hello.html"};
+        session->SetUrl(url);
+
+        // Proceed the chain
+        std::vector<Response> response = proceed(multi);
+        EXPECT_FALSE(response.empty());
+
+        // Restore the url again
+        response.front().url = old_url;
+        return response;
+    }
+};
+
+class ChangeStatusCodeInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        std::shared_ptr<Session> session = multi.GetSessions().front().first;
+
+        // Proceed the chain
+        std::vector<Response> response = proceed(multi);
+        EXPECT_FALSE(response.empty());
+
+        // Change the status code
+        response.front().status_code = 12345;
+        return response;
+    }
+};
+
+class SetBasicAuthInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        std::shared_ptr<Session> session = multi.GetSessions().front().first;
+
+        // Set authentication
+        session->SetAuth(Authentication{"user", "password", AuthMode::BASIC});
+
+        // Proceed the chain
+        return proceed(multi);
+    }
+};
+
+class SetUnsupportedProtocolErrorInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        std::shared_ptr<Session> session = multi.GetSessions().front().first;
+
+        // Proceed the chain
+        std::vector<Response> response = proceed(multi);
+        EXPECT_FALSE(response.empty());
+
+        // Set unsupported protocol error
+        response.front().error = Error{CURLE_UNSUPPORTED_PROTOCOL, "SetErrorInterceptorMulti"};
+
+        // Return response
+        return response;
+    }
+};
+
+class ChangeRequestMethodToGetInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        multi.GetSessions().front().second = MultiPerform::HttpMethod::GET_REQUEST;
+
+        return proceed(multi);
+    }
+};
+
+class ChangeRequestMethodToPostInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        multi.GetSessions().front().second = MultiPerform::HttpMethod::POST_REQUEST;
+        multi.GetSessions().front().first->SetOption(Payload{{"x", "5"}});
+        return proceed(multi);
+    }
+};
+
+class ChangeRequestMethodToPutInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        multi.GetSessions().front().second = MultiPerform::HttpMethod::PUT_REQUEST;
+        multi.GetSessions().front().first->SetOption(Payload{{"x", "5"}});
+        return proceed(multi);
+    }
+};
+
+class ChangeRequestMethodToDeleteInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        multi.GetSessions().front().second = MultiPerform::HttpMethod::DELETE_REQUEST;
+        return proceed(multi);
+    }
+};
+
+bool write_data(std::string /*data*/, intptr_t /*userdata*/) {
+    return true;
+}
+
+class ChangeRequestMethodToDownloadCallbackInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        PrepareDownloadSession(multi, 0, WriteCallback{write_data, 0});
+        multi.GetSessions().front().second = MultiPerform::HttpMethod::DOWNLOAD_REQUEST;
+        return proceed(multi);
+    }
+};
+
+class ChangeRequestMethodToHeadInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        multi.GetSessions().front().second = MultiPerform::HttpMethod::HEAD_REQUEST;
+        return proceed(multi);
+    }
+};
+
+class ChangeRequestMethodToOptionsInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        multi.GetSessions().front().second = MultiPerform::HttpMethod::OPTIONS_REQUEST;
+        return proceed(multi);
+    }
+};
+
+class ChangeRequestMethodToPatchInterceptorMulti : public InterceptorMulti {
+  public:
+    std::vector<Response> intercept(MultiPerform& multi) override {
+        EXPECT_FALSE(multi.GetSessions().empty());
+        multi.GetSessions().front().second = MultiPerform::HttpMethod::PATCH_REQUEST;
+        multi.GetSessions().front().first->SetOption(Payload{{"x", "5"}});
+        return proceed(multi);
+    }
+};
+
+TEST(InterceptorMultiTest, HiddenUrlRewriteInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/basic.json"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<HiddenHelloWorldRedirectInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_text{"Hello world!"};
+    EXPECT_EQ(expected_text, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, ChangeStatusCodeInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<ChangeStatusCodeInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    long expected_status_code{12345};
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(expected_status_code, response.front().status_code);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, DownloadChangeStatusCodeInterceptorMultiTest) {
+    cpr::Url url{server->GetBaseUrl() + "/download_gzip.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    session->SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<ChangeStatusCodeInterceptorMulti>());
+    std::vector<Response> response = multi.Download(cpr::WriteCallback{write_data, 0});
+    EXPECT_EQ(response.size(), 1);
+
+    long expected_status_code{12345};
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(expected_status_code, response.front().status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, SetBasicAuthInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/basic_auth.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<SetBasicAuthInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_text{"Header reflect GET"};
+    EXPECT_EQ(expected_text, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(std::string{"text/html"}, response.front().header["content-type"]);
+    EXPECT_EQ(200, response.front().status_code);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, SetUnsupportedProtocolErrorInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<SetUnsupportedProtocolErrorInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_error_message{"SetErrorInterceptorMulti"};
+    ErrorCode expected_error_code{ErrorCode::UNSUPPORTED_PROTOCOL};
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(std::string{"text/html"}, response.front().header["content-type"]);
+    EXPECT_EQ(200, response.front().status_code);
+    EXPECT_EQ(expected_error_message, response.front().error.message);
+    EXPECT_EQ(expected_error_code, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, ChangeRequestMethodToGetInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<ChangeRequestMethodToGetInterceptorMulti>());
+    std::vector<Response> response = multi.Head();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_text{"Hello world!"};
+    EXPECT_EQ(expected_text, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(std::string{"text/html"}, response.front().header["content-type"]);
+    EXPECT_EQ(200, response.front().status_code);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, ChangeRequestMethodToPostInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/url_post.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<ChangeRequestMethodToPostInterceptorMulti>());
+    std::vector<Response> response = multi.Head();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_text{
+            "{\n"
+            "  \"x\": 5\n"
+            "}"};
+    EXPECT_EQ(expected_text, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(std::string{"application/json"}, response.front().header["content-type"]);
+    EXPECT_EQ(201, response.front().status_code);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, ChangeRequestMethodToPutInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/put.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<ChangeRequestMethodToPutInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_text{
+            "{\n"
+            "  \"x\": 5\n"
+            "}"};
+    EXPECT_EQ(expected_text, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(std::string{"application/json"}, response.front().header["content-type"]);
+    EXPECT_EQ(200, response.front().status_code);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, ChangeRequestMethodToPatchInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/patch.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<ChangeRequestMethodToPatchInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_text{
+            "{\n"
+            "  \"x\": 5\n"
+            "}"};
+    EXPECT_EQ(expected_text, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(std::string{"application/json"}, response.front().header["content-type"]);
+    EXPECT_EQ(200, response.front().status_code);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, ChangeRequestMethodToOptionsInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<ChangeRequestMethodToOptionsInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_text{""};
+    EXPECT_EQ(expected_text, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"}, response.front().header["Access-Control-Allow-Methods"]);
+    EXPECT_EQ(200, response.front().status_code);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, ChangeRequestMethodToHeadInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<ChangeRequestMethodToHeadInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    EXPECT_EQ(std::string{}, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(std::string{"text/html"}, response.front().header["content-type"]);
+    EXPECT_EQ(200, response.front().status_code);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, ChangeRequestMethodToDownloadCallbackInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/download_gzip.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    session->SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+    session->SetTimeout(Timeout{2000});
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<ChangeRequestMethodToDownloadCallbackInterceptorMulti>());
+    std::vector<Response> response = multi.Put();
+    EXPECT_EQ(response.size(), 1);
+
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(200, response.front().status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, ChangeRequestMethodToDeleteInterceptorMultiTest) {
+    Url url{server->GetBaseUrl() + "/delete.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<ChangeRequestMethodToDeleteInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_text{"Delete success"};
+    EXPECT_EQ(expected_text, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(std::string{"text/html"}, response.front().header["content-type"]);
+    EXPECT_EQ(200, response.front().status_code);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, TwoInterceptorMultisTest) {
+    Url url{server->GetBaseUrl() + "/basic.json"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<HiddenHelloWorldRedirectInterceptorMulti>());
+    multi.AddInterceptor(std::make_shared<ChangeStatusCodeInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_text{"Hello world!"};
+    long expected_status_code{12345};
+    EXPECT_EQ(expected_text, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(expected_status_code, response.front().status_code);
+    EXPECT_EQ(ErrorCode::OK, response.front().error.code);
+}
+
+TEST(InterceptorMultiTest, ThreeInterceptorMultisTest) {
+    Url url{server->GetBaseUrl() + "/basic.json"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multi;
+    multi.AddSession(session);
+    multi.AddInterceptor(std::make_shared<HiddenHelloWorldRedirectInterceptorMulti>());
+    multi.AddInterceptor(std::make_shared<ChangeStatusCodeInterceptorMulti>());
+    multi.AddInterceptor(std::make_shared<SetUnsupportedProtocolErrorInterceptorMulti>());
+    std::vector<Response> response = multi.Get();
+    EXPECT_EQ(response.size(), 1);
+
+    std::string expected_text{"Hello world!"};
+    long expected_status_code{12345};
+    std::string expected_error_message{"SetErrorInterceptorMulti"};
+    ErrorCode expected_error_code{ErrorCode::UNSUPPORTED_PROTOCOL};
+    EXPECT_EQ(expected_text, response.front().text);
+    EXPECT_EQ(url, response.front().url);
+    EXPECT_EQ(expected_status_code, response.front().status_code);
+    EXPECT_EQ(expected_error_message, response.front().error.message);
+    EXPECT_EQ(expected_error_code, response.front().error.code);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(server);
+    return RUN_ALL_TESTS();
+}

--- a/test/interceptor_multi_tests.cpp
+++ b/test/interceptor_multi_tests.cpp
@@ -383,6 +383,26 @@ TEST(InterceptorMultiTest, ChangeRequestMethodToDownloadCallbackInterceptorMulti
     EXPECT_EQ(cpr::ErrorCode::OK, response.front().error.code);
 }
 
+TEST(InterceptorMultiTest, ChangeRequestMethodToDownloadCallbackInterceptorMultiMixTest) {
+    Url url{server->GetBaseUrl() + "/download_gzip.html"};
+    std::shared_ptr<Session> session1 = std::make_shared<Session>();
+    session1->SetUrl(url);
+    session1->SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+    session1->SetTimeout(Timeout{2000});
+
+    std::shared_ptr<Session> session2 = std::make_shared<Session>();
+    session2->SetUrl(url);
+    session2->SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+    session2->SetTimeout(Timeout{2000});
+
+    MultiPerform multi;
+    multi.AddSession(session1);
+    multi.AddSession(session2);
+    // Changes only one of two sessions to download, so it is expected to throw an exception here since we can not mix them.
+    multi.AddInterceptor(std::make_shared<ChangeRequestMethodToDownloadCallbackInterceptorMulti>());
+    EXPECT_THROW(multi.Put(), std::invalid_argument);
+}
+
 TEST(InterceptorMultiTest, ChangeRequestMethodToDeleteInterceptorMultiTest) {
     Url url{server->GetBaseUrl() + "/delete.html"};
     std::shared_ptr<Session> session = std::make_shared<Session>();

--- a/test/interceptor_tests.cpp
+++ b/test/interceptor_tests.cpp
@@ -18,7 +18,7 @@ class HiddenHelloWorldRedirectInterceptor : public Interceptor {
         Url url{server->GetBaseUrl() + "/hello.html"};
         session.SetUrl(url);
 
-        // Procceed the chain
+        // Proceed the chain
         Response response = proceed(session);
 
         // Restore the url again
@@ -30,7 +30,7 @@ class HiddenHelloWorldRedirectInterceptor : public Interceptor {
 class ChangeStatusCodeInterceptor : public Interceptor {
   public:
     Response intercept(Session& session) override {
-        // Procceed the chain
+        // Proceed the chain
         Response response = proceed(session);
 
         // Change the status code
@@ -45,7 +45,7 @@ class SetBasicAuthInterceptor : public Interceptor {
         // Set authentication
         session.SetAuth(Authentication{"user", "password", AuthMode::BASIC});
 
-        // Procceed the chain
+        // Proceed the chain
         return proceed(session);
     }
 };
@@ -53,7 +53,7 @@ class SetBasicAuthInterceptor : public Interceptor {
 class SetUnsupportedProtocolErrorInterceptor : public Interceptor {
   public:
     Response intercept(Session& session) override {
-        // Procceed the chain
+        // Proceed the chain
         Response response = proceed(session);
 
         // Set unsupported protocol error


### PR DESCRIPTION
This PR adds support for intercepts when using `cpr::MultiPerform`.
Fixes #862.

Examples:
```c++
class LoggingInterceptor : public InterceptorMulti {
  public:
    std::vector<Response> intercept(MultiPerform& multi) {
        // Log the request URL
        std::cout << "Request url:  " << multi.GetSessions().front().first->GetFullRequestUrl(); << '\n';

        // Proceed the request and save the response
        std::vector<cpr::Response> response = proceed(multi);

        // Log response status code
        std::cout << "Response status code:  " << response.front().status_code << '\n';

        // Return the stored response
        return response;
    }
};

int main() {
    Url url{"https://example.com"};
    std::shared_ptr<Session> session = std::make_shared<Session>();
    session->SetUrl(url);

    MultiPerform multi;
    multi.AddSession(session);
    multi.AddInterceptor(std::make_shared<LoggingInterceptor>());

    std::vector<Response> response = multi.Get();
}
```
