### PR TITLE
MultiAsync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ _site/
 
 # Vim
 .ycm_extra_conf.py*
+*.swp
 
 # VSCode
 .vscode/
@@ -51,6 +52,10 @@ _site/
 
 # clangd
 .cache/
+
+# compilation database
+# used in various editor configurations, such as vim & YcM
+compile_commands.json
 
 # macOS
 .DS_Store

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(cpr
         async.cpp
         auth.cpp
         bearer.cpp
+        callback.cpp
         cert_info.cpp
         cookies.cpp
         cprtypes.cpp

--- a/cpr/callback.cpp
+++ b/cpr/callback.cpp
@@ -1,5 +1,5 @@
-#include <curl/curl.h>
 #include <cpr/callback.h>
+#include <curl/curl.h>
 #include <functional>
 
 namespace cpr {
@@ -7,10 +7,8 @@ namespace cpr {
 void CancellationCallback::SetProgressCallback(ProgressCallback& u_cb) {
     user_cb.emplace(std::reference_wrapper{u_cb});
 }
-bool CancellationCallback::operator() (cpr_pf_arg_t dltotal, cpr_pf_arg_t dlnow, cpr_pf_arg_t ultotal, cpr_pf_arg_t ulnow) const {
+bool CancellationCallback::operator()(cpr_pf_arg_t dltotal, cpr_pf_arg_t dlnow, cpr_pf_arg_t ultotal, cpr_pf_arg_t ulnow) const {
     const bool cont_operation{!cancellation_state->load()};
-    return user_cb
-        ?(cont_operation && (*user_cb)(dltotal, dlnow, ultotal, ulnow))
-        :cont_operation;
+    return user_cb ? (cont_operation && (*user_cb)(dltotal, dlnow, ultotal, ulnow)) : cont_operation;
 }
 } // namespace cpr

--- a/cpr/callback.cpp
+++ b/cpr/callback.cpp
@@ -1,0 +1,16 @@
+#include <curl/curl.h>
+#include <cpr/callback.h>
+#include <functional>
+
+namespace cpr {
+
+void CancellationCallback::SetProgressCallback(ProgressCallback& u_cb) {
+    user_cb.emplace(std::reference_wrapper{u_cb});
+}
+bool CancellationCallback::operator() (cpr_pf_arg_t dltotal, cpr_pf_arg_t dlnow, cpr_pf_arg_t ultotal, cpr_pf_arg_t ulnow) const {
+    const bool cont_operation{!cancellation_state->load()};
+    return user_cb
+        ?(cont_operation && (*user_cb)(dltotal, dlnow, ultotal, ulnow))
+        :cont_operation;
+}
+} // namespace cpr

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -246,11 +246,15 @@ void Session::SetWriteCallback(const WriteCallback& write) {
 
 void Session::SetProgressCallback(const ProgressCallback& progress) {
     progresscb_ = progress;
+    if(isCancellable) {
+        cancellationcb_.SetProgressCallback(progresscb_);
+        return;
+    }
 #if LIBCURL_VERSION_NUM < 0x072000
     curl_easy_setopt(curl_->handle, CURLOPT_PROGRESSFUNCTION, cpr::util::progressUserFunction);
     curl_easy_setopt(curl_->handle, CURLOPT_PROGRESSDATA, &progresscb_);
 #else
-    curl_easy_setopt(curl_->handle, CURLOPT_XFERINFOFUNCTION, cpr::util::progressUserFunction);
+    curl_easy_setopt(curl_->handle, CURLOPT_XFERINFOFUNCTION, cpr::util::progressUserFunction<ProgressCallback>);
     curl_easy_setopt(curl_->handle, CURLOPT_XFERINFODATA, &progresscb_);
 #endif
     curl_easy_setopt(curl_->handle, CURLOPT_NOPROGRESS, 0L);
@@ -968,4 +972,18 @@ void Session::SetOption(const ReserveSize& reserve_size) { SetReserveSize(reserv
 void Session::SetOption(const AcceptEncoding& accept_encoding) { SetAcceptEncoding(accept_encoding); }
 void Session::SetOption(AcceptEncoding&& accept_encoding) { SetAcceptEncoding(accept_encoding); }
 // clang-format on
+
+void Session::SetCancellationParam(std::shared_ptr<std::atomic_bool> param) {
+    cancellationcb_ = CancellationCallback{std::move(param)};
+    isCancellable = true;
+#if LIBCURL_VERSION_NUM < 0x072000
+    curl_easy_setopt(curl_->handle, CURLOPT_PROGRESSFUNCTION, cpr::util::progressUserFunction);
+    curl_easy_setopt(curl_->handle, CURLOPT_PROGRESSDATA, &cancellationcb_);
+#else
+    curl_easy_setopt(curl_->handle, CURLOPT_XFERINFOFUNCTION, cpr::util::progressUserFunction<CancellationCallback>);
+    curl_easy_setopt(curl_->handle, CURLOPT_XFERINFODATA, &cancellationcb_);
+#endif
+    curl_easy_setopt(curl_->handle, CURLOPT_NOPROGRESS, 0L);
+
+}
 } // namespace cpr

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -251,7 +251,7 @@ void Session::SetProgressCallback(const ProgressCallback& progress) {
         return;
     }
 #if LIBCURL_VERSION_NUM < 0x072000
-    curl_easy_setopt(curl_->handle, CURLOPT_PROGRESSFUNCTION, cpr::util::progressUserFunction);
+    curl_easy_setopt(curl_->handle, CURLOPT_PROGRESSFUNCTION, cpr::util::progressUserFunction<ProgressCallback>);
     curl_easy_setopt(curl_->handle, CURLOPT_PROGRESSDATA, &progresscb_);
 #else
     curl_easy_setopt(curl_->handle, CURLOPT_XFERINFOFUNCTION, cpr::util::progressUserFunction<ProgressCallback>);
@@ -977,7 +977,7 @@ void Session::SetCancellationParam(std::shared_ptr<std::atomic_bool> param) {
     cancellationcb_ = CancellationCallback{std::move(param)};
     isCancellable = true;
 #if LIBCURL_VERSION_NUM < 0x072000
-    curl_easy_setopt(curl_->handle, CURLOPT_PROGRESSFUNCTION, cpr::util::progressUserFunction);
+    curl_easy_setopt(curl_->handle, CURLOPT_PROGRESSFUNCTION, cpr::util::progressUserFunction<CancellationCallback>);
     curl_easy_setopt(curl_->handle, CURLOPT_PROGRESSDATA, &cancellationcb_);
 #else
     curl_easy_setopt(curl_->handle, CURLOPT_XFERINFOFUNCTION, cpr::util::progressUserFunction<CancellationCallback>);

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -246,7 +246,7 @@ void Session::SetWriteCallback(const WriteCallback& write) {
 
 void Session::SetProgressCallback(const ProgressCallback& progress) {
     progresscb_ = progress;
-    if(isCancellable) {
+    if (isCancellable) {
         cancellationcb_.SetProgressCallback(progresscb_);
         return;
     }
@@ -984,6 +984,5 @@ void Session::SetCancellationParam(std::shared_ptr<std::atomic_bool> param) {
     curl_easy_setopt(curl_->handle, CURLOPT_XFERINFODATA, &cancellationcb_);
 #endif
     curl_easy_setopt(curl_->handle, CURLOPT_NOPROGRESS, 0L);
-
 }
 } // namespace cpr

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -144,14 +144,6 @@ size_t writeUserFunction(char* ptr, size_t size, size_t nmemb, const WriteCallba
     return (*write)({ptr, size}) ? size : 0;
 }
 
-#if LIBCURL_VERSION_NUM < 0x072000
-int progressUserFunction(const ProgressCallback* progress, double dltotal, double dlnow, double ultotal, double ulnow) {
-#else
-int progressUserFunction(const ProgressCallback* progress, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
-#endif
-    return (*progress)(dltotal, dlnow, ultotal, ulnow) ? 0 : 1;
-} // namespace cpr::util
-
 int debugUserFunction(CURL* /*handle*/, curl_infotype type, char* data, size_t size, const DebugCallback* debug) {
     (*debug)(static_cast<DebugCallback::InfoType>(type), std::string(data, size));
     return 0;

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(cpr PRIVATE
     cpr/accept_encoding.h
     cpr/api.h
     cpr/async.h
+    cpr/async_wrapper.h
     cpr/auth.h
     cpr/bearer.h
     cpr/body.h

--- a/include/cpr/api.h
+++ b/include/cpr/api.h
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "cpr/async.h"
+#include "cpr/async_wrapper.h"
 #include "cpr/auth.h"
 #include "cpr/bearer.h"
 #include "cpr/cprtypes.h"
@@ -17,11 +18,10 @@
 #include "cpr/response.h"
 #include "cpr/session.h"
 #include <cpr/filesystem.h>
-#include <utility>
 
 namespace cpr {
 
-using AsyncResponse = std::future<Response>;
+using AsyncResponse = AsyncWrapper<Response>;
 
 namespace priv {
 
@@ -245,7 +245,7 @@ Response Download(std::ofstream& file, Ts&&... ts) {
 // Download async method
 template <typename... Ts>
 AsyncResponse DownloadAsync(fs::path local_path, Ts... ts) {
-    return std::async(
+    return AsyncResponse{std::async(
             std::launch::async,
             [](fs::path local_path_, Ts... ts_) {
 #ifdef CPR_USE_BOOST_FILESYSTEM
@@ -255,7 +255,7 @@ AsyncResponse DownloadAsync(fs::path local_path, Ts... ts) {
 #endif
                 return Download(f, std::move(ts_)...);
             },
-            std::move(local_path), std::move(ts)...);
+            std::move(local_path), std::move(ts)...)};
 }
 
 // Download with user callback

--- a/include/cpr/api.h
+++ b/include/cpr/api.h
@@ -85,7 +85,7 @@ void setup_multiperform(MultiPerform& multiperform, Ts&&... ts) {
     setup_multiperform_internal<Ts...>(multiperform, std::forward<Ts>(ts)...);
 }
 
-using session_action_t= decltype(&cpr::Session::Get);
+using session_action_t = cpr::Response(cpr::Session::*)();
 
 template <session_action_t SessionAction, typename T>
 void setup_multiasync(std::vector<AsyncWrapper<Response, true>>& responses, T&& parameters) {
@@ -349,6 +349,49 @@ std::vector<AsyncWrapper<Response, true>> MultiGetAsync(Ts&&... ts) {
     priv::setup_multiasync<&cpr::Session::Get>(ret, std::forward<Ts>(ts)...);
     return ret;
 }
+
+template <typename... Ts>
+std::vector<AsyncWrapper<Response, true>> MultiDeleteAsync(Ts&&... ts) {
+    std::vector<AsyncWrapper<Response, true>> ret{};
+    priv::setup_multiasync<&cpr::Session::Delete>(ret, std::forward<Ts>(ts)...);
+    return ret;
+}
+
+template <typename... Ts>
+std::vector<AsyncWrapper<Response, true>> MultiHeadAsync(Ts&&... ts) {
+    std::vector<AsyncWrapper<Response, true>> ret{};
+    priv::setup_multiasync<&cpr::Session::Head>(ret, std::forward<Ts>(ts)...);
+    return ret;
+}
+template <typename... Ts>
+std::vector<AsyncWrapper<Response, true>> MultiOptionsAsync(Ts&&... ts) {
+    std::vector<AsyncWrapper<Response, true>> ret{};
+    priv::setup_multiasync<&cpr::Session::Options>(ret, std::forward<Ts>(ts)...);
+    return ret;
+}
+
+template <typename... Ts>
+std::vector<AsyncWrapper<Response, true>> MultiPatchAsync(Ts&&... ts) {
+    std::vector<AsyncWrapper<Response, true>> ret{};
+    priv::setup_multiasync<&cpr::Session::Patch>(ret, std::forward<Ts>(ts)...);
+    return ret;
+}
+
+template <typename... Ts>
+std::vector<AsyncWrapper<Response, true>> MultiPostAsync(Ts&&... ts) {
+    std::vector<AsyncWrapper<Response, true>> ret{};
+    priv::setup_multiasync<&cpr::Session::Post>(ret, std::forward<Ts>(ts)...);
+    return ret;
+}
+
+template <typename... Ts>
+std::vector<AsyncWrapper<Response, true>> MultiPutAsync(Ts&&... ts) {
+    std::vector<AsyncWrapper<Response, true>> ret{};
+    priv::setup_multiasync<&cpr::Session::Put>(ret, std::forward<Ts>(ts)...);
+    return ret;
+}
+
+
 } // namespace cpr
 
 #endif

--- a/include/cpr/async.h
+++ b/include/cpr/async.h
@@ -2,7 +2,6 @@
 #define CPR_ASYNC_H
 
 #include "async_wrapper.h"
-#include "session.h"
 #include "singleton.h"
 #include "threadpool.h"
 
@@ -18,7 +17,7 @@ class GlobalThreadPool : public ThreadPool {
 };
 
 /**
- * Return a wraper for a future, calling future.get() will wait until the task is done and return RetType.
+ * Return a wrapper for a future, calling future.get() will wait until the task is done and return RetType.
  * async(fn, args...)
  * async(std::bind(&Class::mem_fn, &obj))
  * async(std::mem_fn(&Class::mem_fn, &obj))

--- a/include/cpr/async.h
+++ b/include/cpr/async.h
@@ -1,10 +1,10 @@
 #ifndef CPR_ASYNC_H
 #define CPR_ASYNC_H
 
-#include "singleton.h"
-#include "threadpool.h"
 #include "async_wrapper.h"
 #include "session.h"
+#include "singleton.h"
+#include "threadpool.h"
 
 namespace cpr {
 

--- a/include/cpr/async.h
+++ b/include/cpr/async.h
@@ -3,6 +3,8 @@
 
 #include "singleton.h"
 #include "threadpool.h"
+#include "async_wrapper.h"
+#include "session.h"
 
 namespace cpr {
 
@@ -16,14 +18,14 @@ class GlobalThreadPool : public ThreadPool {
 };
 
 /**
- * Return a future, calling future.get() will wait task done and return RetType.
+ * Return a wraper for a future, calling future.get() will wait until the task is done and return RetType.
  * async(fn, args...)
  * async(std::bind(&Class::mem_fn, &obj))
  * async(std::mem_fn(&Class::mem_fn, &obj))
  **/
 template <class Fn, class... Args>
 auto async(Fn&& fn, Args&&... args) {
-    return GlobalThreadPool::GetInstance()->Submit(std::forward<Fn>(fn), std::forward<Args>(args)...);
+    return AsyncWrapper{GlobalThreadPool::GetInstance()->Submit(std::forward<Fn>(fn), std::forward<Args>(args)...)};
 }
 
 class async {

--- a/include/cpr/async_wrapper.h
+++ b/include/cpr/async_wrapper.h
@@ -41,7 +41,7 @@ class AsyncWrapper {
     ~AsyncWrapper() {
         if constexpr (isCancellable) {
             if(is_cancelled) {
-                is_cancelled->store(false);
+                is_cancelled->store(true);
             }
         }
     }

--- a/include/cpr/async_wrapper.h
+++ b/include/cpr/async_wrapper.h
@@ -38,7 +38,13 @@ class AsyncWrapper {
     AsyncWrapper& operator=(AsyncWrapper&&) noexcept = default;
 
     // Destructor
-    ~AsyncWrapper() = default;
+    ~AsyncWrapper() {
+        if constexpr (isCancellable) {
+            if(is_cancelled) {
+                is_cancelled->store(false);
+            }
+        }
+    }
 
 
     // These methods replicate the behaviour of std::future<T>

--- a/include/cpr/async_wrapper.h
+++ b/include/cpr/async_wrapper.h
@@ -8,8 +8,6 @@
 #include "cpr/response.h"
 
 namespace cpr {
-
-
 enum class [[nodiscard]] CancellationResult { failure, success, invalid_operation };
 
 /**
@@ -45,8 +43,6 @@ class AsyncWrapper {
             }
         }
     }
-
-
     // These methods replicate the behaviour of std::future<T>
     [[nodiscard]] T get() {
         if constexpr (isCancellable) {

--- a/include/cpr/async_wrapper.h
+++ b/include/cpr/async_wrapper.h
@@ -1,0 +1,140 @@
+#ifndef CPR_ASYNC_WRAPPER_H
+#define CPR_ASYNC_WRAPPER_H
+
+#include <atomic>
+#include <future>
+#include <memory>
+
+#include "cpr/response.h"
+
+namespace cpr {
+
+
+enum class [[nodiscard]] CancellationResult {
+    failure,
+    success,
+    invalid_operation
+};
+
+/**
+ * A class template intended to wrap results of async operations (instances of std::future<T>)
+ * and also provide extended capablilities relaed to these requests, for example cancellation.
+ *
+ * The RAII semantics are the same as std::future<T> - moveable, not copyable.
+ */
+template<typename T, bool isCancellable = false>
+class AsyncWrapper {
+    private:
+    std::future<T> future;
+    std::shared_ptr<std::atomic_bool> is_cancelled;
+
+    public:
+
+    // Constructors
+    explicit AsyncWrapper(std::future<T>&& f): future{std::move(f)} {}
+    AsyncWrapper(std::future<T>&& f, std::shared_ptr<std::atomic_bool>&& cancelledState): future{std::move(f)}, is_cancelled{std::move(cancelledState)} {}
+
+    // Copy Semantics
+    AsyncWrapper(const AsyncWrapper&) = delete;
+    AsyncWrapper& operator=(const AsyncWrapper&) = delete;
+
+    // Move Semantics
+    AsyncWrapper(AsyncWrapper&&) noexcept = default;
+    AsyncWrapper& operator=(AsyncWrapper&&) noexcept = default;
+
+    // Destructor
+    ~AsyncWrapper() = default;
+
+
+    // These methods replicate the behaviour of std::future<T>
+    [[nodiscard]]
+    T get() {
+        if constexpr (isCancellable) {
+            if(isCancelled()) {
+                throw std::logic_error{"Calling AsyncWrapper::get on a cancelled request!"};
+            }
+        }
+        if(!future.valid()) {
+            throw std::logic_error{"Calling AsyncWrapper::get when the associated future instance has been invalidated!"};
+        }
+        return future.get();
+    }
+
+    [[nodiscard]]
+    bool valid() const noexcept {
+        if constexpr (isCancellable) {
+            return !is_cancelled->load() && future.valid();
+        } else {
+            return future.valid();
+        }
+    }
+
+    void wait() const {
+        if constexpr (isCancellable) {
+            if(!future.valid() || is_cancelled->load()) {
+                throw std::logic_error{"Calling AsyncWrapper::wait when the associated future is invalid or cancelled!"};
+            }
+        }
+        future.wait();
+    }
+
+    template<class Rep, class Period>
+    std::future_status wait_for(const std::chrono::duration<Rep, Period>& timeout_duration) const {
+        if constexpr (isCancellable) {
+            if(isCancelled()) {
+                throw std::logic_error{"Calling AsyncWrapper::wait_for when the associated future is cancelled!"};
+            }
+        }
+        return future.wait_for(timeout_duration);
+    }
+
+    template<class Clock, class Duration>
+    std::future_status wait_until(const std::chrono::time_point<Clock, Duration>& timeout_time) const {
+        if constexpr (isCancellable) {
+            if(isCancelled()) {
+                throw std::logic_error{"Calling AsyncWrapper::wait_until when the associated future is cancelled!"};
+            }
+        }
+        return future.wait_until(timeout_time);
+    }
+
+    std::shared_future<T> share() noexcept {
+       return future.share();
+    }
+
+    // Cancellation-related methods
+    CancellationResult cancel() {
+        if constexpr (!isCancellable) {
+            return CancellationResult::invalid_operation;
+        }
+        if(!future.valid() || is_cancelled->load()) {
+            return CancellationResult::invalid_operation;
+        }
+        is_cancelled->store(true);
+        return CancellationResult::success;
+   }
+
+    [[nodiscard]]
+    bool isCancelled() const {
+        if constexpr (isCancellable) {
+            return is_cancelled->load();
+        } else {
+            return false;
+        }
+    }
+
+};
+
+// Deduction guides
+template<typename T>
+AsyncWrapper(std::future<T>&&)
+    -> AsyncWrapper<T, false>;
+
+template<typename T>
+AsyncWrapper(std::future<T>&&, std::shared_ptr<std::atomic_bool>&&)
+    -> AsyncWrapper<T, true>;
+
+} // namespace cpr
+
+
+#endif

--- a/include/cpr/async_wrapper.h
+++ b/include/cpr/async_wrapper.h
@@ -50,12 +50,12 @@ class AsyncWrapper {
     [[nodiscard]]
     T get() {
         if constexpr (isCancellable) {
-            if(isCancelled()) {
+            if(IsCancelled()) {
                 throw std::logic_error{"Calling AsyncWrapper::get on a cancelled request!"};
             }
         }
         if(!future.valid()) {
-            throw std::logic_error{"Calling AsyncWrapper::get when the associated future instance has been invalidated!"};
+            throw std::logic_error{"Calling AsyncWrapper::get when the associated future instance is invalid!"};
         }
         return future.get();
     }
@@ -71,9 +71,12 @@ class AsyncWrapper {
 
     void wait() const {
         if constexpr (isCancellable) {
-            if(!future.valid() || is_cancelled->load()) {
+            if(is_cancelled->load()) {
                 throw std::logic_error{"Calling AsyncWrapper::wait when the associated future is invalid or cancelled!"};
             }
+        }
+        if(!future.valid()) {
+            throw std::logic_error{"Calling AsyncWrapper::wait_until when the associated future is invalid!"};
         }
         future.wait();
     }
@@ -81,9 +84,12 @@ class AsyncWrapper {
     template<class Rep, class Period>
     std::future_status wait_for(const std::chrono::duration<Rep, Period>& timeout_duration) const {
         if constexpr (isCancellable) {
-            if(isCancelled()) {
+            if(IsCancelled()) {
                 throw std::logic_error{"Calling AsyncWrapper::wait_for when the associated future is cancelled!"};
             }
+        }
+        if(!future.valid()) {
+            throw std::logic_error{"Calling AsyncWrapper::wait_until when the associated future is invalid!"};
         }
         return future.wait_for(timeout_duration);
     }
@@ -91,9 +97,12 @@ class AsyncWrapper {
     template<class Clock, class Duration>
     std::future_status wait_until(const std::chrono::time_point<Clock, Duration>& timeout_time) const {
         if constexpr (isCancellable) {
-            if(isCancelled()) {
+            if(IsCancelled()) {
                 throw std::logic_error{"Calling AsyncWrapper::wait_until when the associated future is cancelled!"};
             }
+        }
+        if(!future.valid()) {
+            throw std::logic_error{"Calling AsyncWrapper::wait_until when the associated future is invalid!"};
         }
         return future.wait_until(timeout_time);
     }
@@ -103,7 +112,7 @@ class AsyncWrapper {
     }
 
     // Cancellation-related methods
-    CancellationResult cancel() {
+    CancellationResult Cancel() {
         if constexpr (!isCancellable) {
             return CancellationResult::invalid_operation;
         }
@@ -115,7 +124,7 @@ class AsyncWrapper {
    }
 
     [[nodiscard]]
-    bool isCancelled() const {
+    bool IsCancelled() const {
         if constexpr (isCancellable) {
             return is_cancelled->load();
         } else {

--- a/include/cpr/callback.h
+++ b/include/cpr/callback.h
@@ -55,13 +55,13 @@ class ProgressCallback {
   public:
     ProgressCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    ProgressCallback(std::function<bool(cpr_off_t downloadTotal, cpr_off_t downloadNow, cpr_off_t uploadTotal, cpr_off_t uploadNow, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
-    bool operator()(cpr_off_t downloadTotal, cpr_off_t downloadNow, cpr_off_t uploadTotal, cpr_off_t uploadNow) const {
+    ProgressCallback(std::function<bool(cpr_pf_arg_t downloadTotal, cpr_pf_arg_t downloadNow, cpr_pf_arg_t uploadTotal, cpr_pf_arg_t uploadNow, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    bool operator()(cpr_pf_arg_t downloadTotal, cpr_pf_arg_t downloadNow, cpr_pf_arg_t uploadTotal, cpr_pf_arg_t uploadNow) const {
         return callback(downloadTotal, downloadNow, uploadTotal, uploadNow, userdata);
     }
 
     intptr_t userdata{};
-    std::function<bool(cpr_off_t downloadTotal, cpr_off_t downloadNow, cpr_off_t uploadTotal, cpr_off_t uploadNow, intptr_t userdata)> callback;
+    std::function<bool(cpr_pf_arg_t downloadTotal, cpr_pf_arg_t downloadNow, cpr_pf_arg_t uploadTotal, cpr_pf_arg_t uploadNow, intptr_t userdata)> callback;
 };
 
 class DebugCallback {
@@ -90,18 +90,19 @@ class DebugCallback {
  * Functor class for progress functions that will be used in cancellable requests.
  */
 class CancellationCallback {
-    public:
+  public:
     CancellationCallback() = default;
-    explicit CancellationCallback(std::shared_ptr<std::atomic_bool>&& cs): cancellation_state{std::move(cs)} {}
+    explicit CancellationCallback(std::shared_ptr<std::atomic_bool>&& cs) : cancellation_state{std::move(cs)} {}
 
-    CancellationCallback(std::shared_ptr<std::atomic_bool>&& cs, ProgressCallback& u_cb): cancellation_state{std::move(cs)}, user_cb{std::reference_wrapper{u_cb}} {}
+    CancellationCallback(std::shared_ptr<std::atomic_bool>&& cs, ProgressCallback& u_cb) : cancellation_state{std::move(cs)}, user_cb{std::reference_wrapper{u_cb}} {}
 
-    bool operator() (cpr_pf_arg_t dltotal, cpr_pf_arg_t dlnow, cpr_pf_arg_t ultotal, cpr_pf_arg_t ulnow) const;
+    bool operator()(cpr_pf_arg_t dltotal, cpr_pf_arg_t dlnow, cpr_pf_arg_t ultotal, cpr_pf_arg_t ulnow) const;
 
     void SetProgressCallback(ProgressCallback& u_cb);
-    private:
+
+  private:
     std::shared_ptr<std::atomic_bool> cancellation_state;
-    std::optional<std::reference_wrapper<ProgressCallback>>user_cb;
+    std::optional<std::reference_wrapper<ProgressCallback>> user_cb;
 };
 
 

--- a/include/cpr/cprtypes.h
+++ b/include/cpr/cprtypes.h
@@ -1,6 +1,7 @@
 #ifndef CPR_CPR_TYPES_H
 #define CPR_CPR_TYPES_H
 
+#include <curl/curl.h>
 #include <curl/system.h>
 #include <initializer_list>
 #include <map>
@@ -15,6 +16,15 @@ namespace cpr {
  * Wrapper around "curl_off_t" to prevent applications from having to link against libcurl.
  **/
 using cpr_off_t = curl_off_t;
+
+/**
+ * The argument type for progress functions, dependent on libcurl version
+ **/
+#if LIBCURL_VERSION_NUM < 0x072000
+using cpr_pf_arg_t = double;
+#else
+using cpr_pf_arg_t = cpr_off_t;
+#endif
 
 template <class T>
 class StringHolder {

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -4,12 +4,13 @@
 #include <cstdint>
 #include <fstream>
 #include <future>
+#include <functional>
 #include <memory>
 #include <queue>
 
 #include "cpr/accept_encoding.h"
-#include "cpr/async_wrapper.h"
 #include "cpr/auth.h"
+#include "cpr/async_wrapper.h"
 #include "cpr/bearer.h"
 #include "cpr/body.h"
 #include "cpr/callback.h"
@@ -37,6 +38,7 @@
 #include "cpr/timeout.h"
 #include "cpr/unix_socket.h"
 #include "cpr/user_agent.h"
+#include "cpr/util.h"
 #include "cpr/verbose.h"
 
 namespace cpr {
@@ -105,6 +107,9 @@ class Session : public std::enable_shared_from_this<Session> {
     void SetAcceptEncoding(const AcceptEncoding& accept_encoding);
     void SetAcceptEncoding(AcceptEncoding&& accept_encoding);
     void SetLimitRate(const LimitRate& limit_rate);
+
+    // For cancellable requests
+    void SetCancellationParam(std::shared_ptr<std::atomic_bool> param);
 
     // Used in templated functions
     void SetOption(const Url& url);
@@ -224,6 +229,7 @@ class Session : public std::enable_shared_from_this<Session> {
     friend Interceptor;
     friend MultiPerform;
 
+
     bool hasBodyOrPayload_{false};
     bool chunkedTransferEncoding_{false};
     std::shared_ptr<CurlHolder> curl_;
@@ -242,11 +248,14 @@ class Session : public std::enable_shared_from_this<Session> {
     WriteCallback writecb_;
     ProgressCallback progresscb_;
     DebugCallback debugcb_;
+    CancellationCallback cancellationcb_;
+
     size_t response_string_reserve_size_{0};
     std::string response_string_;
     std::string header_string_;
     std::queue<std::shared_ptr<Interceptor>> interceptors_;
     bool isUsedInMultiPerform{false};
+    bool isCancellable{false};
 
     Response makeDownloadRequest();
     Response makeRequest();

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -3,14 +3,14 @@
 
 #include <cstdint>
 #include <fstream>
-#include <future>
 #include <functional>
+#include <future>
 #include <memory>
 #include <queue>
 
 #include "cpr/accept_encoding.h"
-#include "cpr/auth.h"
 #include "cpr/async_wrapper.h"
+#include "cpr/auth.h"
 #include "cpr/bearer.h"
 #include "cpr/body.h"
 #include "cpr/callback.h"

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -8,6 +8,7 @@
 #include <queue>
 
 #include "cpr/accept_encoding.h"
+#include "cpr/async_wrapper.h"
 #include "cpr/auth.h"
 #include "cpr/bearer.h"
 #include "cpr/body.h"
@@ -40,7 +41,7 @@
 
 namespace cpr {
 
-using AsyncResponse = std::future<Response>;
+using AsyncResponse = AsyncWrapper<Response>;
 
 class Interceptor;
 class MultiPerform;

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -10,8 +10,7 @@
 #include "cpr/cprtypes.h"
 #include "cpr/curlholder.h"
 
-namespace cpr {
-namespace util {
+namespace cpr::util {
 
 Header parseHeader(const std::string& headers, std::string* status_line = nullptr, std::string* reason = nullptr);
 Cookies parseCookies(curl_slist* raw_cookies);
@@ -20,11 +19,15 @@ size_t headerUserFunction(char* ptr, size_t size, size_t nmemb, const HeaderCall
 size_t writeFunction(char* ptr, size_t size, size_t nmemb, std::string* data);
 size_t writeFileFunction(char* ptr, size_t size, size_t nmemb, std::ofstream* file);
 size_t writeUserFunction(char* ptr, size_t size, size_t nmemb, const WriteCallback* write);
-#if LIBCURL_VERSION_NUM < 0x072000
-int progressUserFunction(const ProgressCallback* progress, double dltotal, double dlnow, double ultotal, double ulnow);
-#else
-int progressUserFunction(const ProgressCallback* progress, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
-#endif
+
+template<typename T = ProgressCallback>
+int progressUserFunction(const T* progress, cpr_pf_arg_t dltotal, cpr_pf_arg_t dlnow, cpr_pf_arg_t ultotal, cpr_pf_arg_t ulnow) {
+    const int cancel_retval{1};
+    static_assert(cancel_retval != CURL_PROGRESSFUNC_CONTINUE);
+    return (*progress)(dltotal, dlnow, ultotal, ulnow) ? 0 : cancel_retval;
+}
+
+
 int debugUserFunction(CURL* handle, curl_infotype type, char* data, size_t size, const DebugCallback* debug);
 std::vector<std::string> split(const std::string& to_split, char delimiter);
 std::string urlEncode(const std::string& s);
@@ -39,7 +42,6 @@ std::string urlDecode(const std::string& s);
 void secureStringClear(std::string& s);
 bool isTrue(const std::string& s);
 
-} // namespace util
-} // namespace cpr
+} // namespace cpr::util
 
 #endif

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -26,8 +26,6 @@ int progressUserFunction(const T* progress, cpr_pf_arg_t dltotal, cpr_pf_arg_t d
     static_assert(cancel_retval != CURL_PROGRESSFUNC_CONTINUE);
     return (*progress)(dltotal, dlnow, ultotal, ulnow) ? 0 : cancel_retval;
 }
-
-
 int debugUserFunction(CURL* handle, curl_infotype type, char* data, size_t size, const DebugCallback* debug);
 std::vector<std::string> split(const std::string& to_split, char delimiter);
 std::string urlEncode(const std::string& s);

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -20,7 +20,7 @@ size_t writeFunction(char* ptr, size_t size, size_t nmemb, std::string* data);
 size_t writeFileFunction(char* ptr, size_t size, size_t nmemb, std::ofstream* file);
 size_t writeUserFunction(char* ptr, size_t size, size_t nmemb, const WriteCallback* write);
 
-template<typename T = ProgressCallback>
+template <typename T = ProgressCallback>
 int progressUserFunction(const T* progress, cpr_pf_arg_t dltotal, cpr_pf_arg_t dlnow, cpr_pf_arg_t ultotal, cpr_pf_arg_t ulnow) {
     const int cancel_retval{1};
     static_assert(cancel_retval != CURL_PROGRESSFUNC_CONTINUE);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,10 +63,11 @@ add_cpr_test(interceptor)
 add_cpr_test(interceptor_multi)
 add_cpr_test(multiperform)
 add_cpr_test(resolve)
+add_cpr_test(multiasync)
 
 if (ENABLE_SSL_TESTS)
     add_cpr_test(ssl)
-    
+
     # Install all ssl keys and certs. Explicit copy for each file to prevent issues when copying on Windows.
     add_custom_command(TARGET ssl_tests POST_BUILD COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:ssl_tests>/data/certificates $<TARGET_FILE_DIR:ssl_tests>/data/keys)
     add_custom_command(TARGET ssl_tests POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/data/certificates/client.crt $<TARGET_FILE_DIR:ssl_tests>/data/certificates/client.crt)

--- a/test/multiasync_tests.cpp
+++ b/test/multiasync_tests.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include <cpr/cpr.h>
+#include <cpr/filesystem.h>
+
+#include "cpr/api.h"
+#include "httpServer.hpp"
+
+using namespace cpr;
+
+static HttpServer* server = new HttpServer();
+
+namespace test_internal {
+
+class IntrospectionFunction {
+    public:
+    explicit IntrospectionFunction(std::function<void()>&& f): introFunc{std::move(f)} {}
+
+
+    private:
+    std::function<void()> introFunc;
+};
+} // namespace test_internal
+
+// A cancellable AsyncResponse
+using AsyncResponseC = AsyncWrapper<Response, true>;
+
+std::vector<AsyncResponseC> threeHelloWorldReqs () {
+    const Url hello_url{server->GetBaseUrl() + "/hello.html"};
+    return MultiGetAsync(std::tuple{hello_url}, std::tuple{hello_url}, std::tuple{hello_url});
+}
+
+TEST(MultiAsyncBasicTests, MultiAsyncGetTest) {
+    const std::string expected_hello{"Hello world!"};
+    std::vector resps{threeHelloWorldReqs()};
+
+    for(AsyncResponseC& resp: resps) {
+        EXPECT_EQ(expected_hello, resp.get().text);
+    }
+}
+
+TEST(MultiAsyncCancelTests, CancellationOnQueue) {
+    const Url hello_url{server->GetBaseUrl() + "/hello.html"};
+    GlobalThreadPool::GetInstance()->Pause();
+    std::vector resps{threeHelloWorldReqs()};
+    std::for_each(resps.begin(), resps.end(),
+        [] (AsyncResponseC& r) {
+            EXPECT_EQ(CancellationResult::success, r.cancel());
+        }
+    );
+    GlobalThreadPool::GetInstance()->Resume();
+    // TODO: add assertions here, declare this test a friend function of AsyncWrapper
+}
+
+/**
+ * This test checks if the interval of calls to the progress function is
+ * acceptable during a low-speed transaction. The server's low_speed_bytes
+ * uri sends 1 Byte/second, and we aim to evaluate that 15 calls to the
+ * progress function happen within 5 seconds. This would indicate that
+ * the user can realistically expect to have their request cancelled within
+ * ~1s on a bad case (low network speed).
+ * INFO this test is not, strictly speaking, deterministic. It depends at the
+ * least on scheduler behaviour. We have tried, however, to set a boundary that
+ * is permissive enough to ensure consistency.
+ */
+TEST(MultiAsyncCancelTest, TestIntervalOfProgressCallsLowSpeed) {
+    const Url call_url{server->GetBaseUrl() + "/low_speed_bytes.html"};
+
+    const size_t N{15};
+
+    // This variable will be used to cancel the transaction at the point of the Nth call.
+    const std::shared_ptr no{std::make_shared<std::atomic_size_t>(0)};
+    const std::chrono::time_point start{std::chrono::steady_clock::now()};
+
+    std::vector resp{MultiGetAsync(std::tuple{call_url, ProgressCallback{std::function{[no] (cpr_off_t a1, cpr_off_t a2, cpr_off_t a3, cpr_off_t  a4, intptr_t a5) {
+        std::ignore = std::tuple(a1, a2, a3, a4, a5);
+        no->store(no->load() + 1);
+        return no->load() < N;
+    }}}})};
+    resp.at(0).wait();
+
+    const std::chrono::duration elapsed_time{std::chrono::steady_clock::now() - start};
+    EXPECT_GT(std::chrono::seconds(N), elapsed_time);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(server);
+    return RUN_ALL_TESTS();
+}

--- a/test/multiasync_tests.cpp
+++ b/test/multiasync_tests.cpp
@@ -23,14 +23,215 @@ std::vector<AsyncResponseC> threeHelloWorldReqs () {
     return MultiGetAsync(std::tuple{hello_url}, std::tuple{hello_url}, std::tuple{hello_url});
 }
 
+/** The group MultiAsyncBasicTests executes multiple tests from the test sources associated with every Http action in parallel.
+ * These tests are reproductions of tests from the appropriate test suites, but they guarantee that the multiasync function template produces correctly working instantiations for every Http action.
+ */
 TEST(MultiAsyncBasicTests, MultiAsyncGetTest) {
     const std::string expected_hello{"Hello world!"};
-    std::vector resps{threeHelloWorldReqs()};
+    std::vector<AsyncResponseC> resps{threeHelloWorldReqs()};
 
     for(AsyncResponseC& resp: resps) {
         EXPECT_EQ(expected_hello, resp.get().text);
     }
 }
+
+TEST(MultiAsyncBasicTests, MultiAsyncDeleteTest) {
+    const std::string server_base{server->GetBaseUrl()};
+    const Url delete_allowed{server_base + "/delete.html"};
+    const Url delete_unallowed{server_base + "/delete_unallowed.html"};
+    const std::tuple del_json_params{delete_allowed, Body{"'foo':'bar'"}, Header{{"Content-Type", "application/json"}}};
+    const std::string expected_text_success{"Delete success"};
+    const std::string expected_text_fail{"Method Not Allowed"};
+    const std::string expected_text_json{"'foo':'bar'"};
+
+    std::vector<AsyncResponseC> resps{MultiDeleteAsync(std::tuple{delete_allowed}, std::tuple{delete_unallowed}, del_json_params)};
+
+    Response del_success{resps.at(0).get()};
+    Response del_fail{resps.at(1).get()};
+    Response del_json{resps.at(2).get()};
+
+    EXPECT_EQ(expected_text_success, del_success.text);
+    EXPECT_EQ(delete_allowed, del_success.url);
+    EXPECT_EQ(std::string{"text/html"}, del_success.header["content-type"]);
+    EXPECT_EQ(200, del_success.status_code);
+    EXPECT_EQ(ErrorCode::OK, del_success.error.code);
+
+    EXPECT_EQ(expected_text_fail, del_fail.text);
+    EXPECT_EQ(delete_unallowed, del_fail.url);
+    EXPECT_EQ(std::string{"text/plain"}, del_fail.header["content-type"]);
+    EXPECT_EQ(405, del_fail.status_code);
+    EXPECT_EQ(ErrorCode::OK, del_fail.error.code);
+
+    EXPECT_EQ(expected_text_json, del_json.text);
+    EXPECT_EQ(delete_allowed, del_json.url);
+    EXPECT_EQ(std::string{"application/json"}, del_json.header["content-type"]);
+    EXPECT_EQ(200, del_json.status_code);
+    EXPECT_EQ(ErrorCode::OK, del_json.error.code);
+}
+
+TEST(MultiAsyncBasicTests, MultiAsyncHeadTest) {
+    const std::string server_base{server->GetBaseUrl()};
+    const Url hello_url{server_base + "/hello.html"};
+    const Url json_url{server_base + "/basic.json"};
+    const Url notfound_url{server_base + "/error.html"};
+    const Url digest_url{server_base + "/digest_auth.html"};
+    const Authentication digest_auth{"user", "password", AuthMode::DIGEST};
+
+    std::vector<AsyncResponseC> resps{MultiHeadAsync(
+            std::tuple{hello_url},
+            std::tuple{json_url},
+            std::tuple{notfound_url},
+            std::tuple{digest_url, digest_auth}
+            )};
+    Response hello_resp{resps.at(0).get()};
+    Response json_resp{resps.at(1).get()};
+    Response notfound_resp{resps.at(2).get()};
+    Response digest_resp{resps.at(3).get()};
+
+    EXPECT_EQ(std::string{}, hello_resp.text);
+    EXPECT_EQ(hello_url, hello_resp.url);
+    EXPECT_EQ(std::string{"text/html"}, hello_resp.header["content-type"]);
+    EXPECT_EQ(200, hello_resp.status_code);
+    EXPECT_EQ(ErrorCode::OK, hello_resp.error.code);
+
+    EXPECT_EQ(std::string{}, json_resp.text);
+    EXPECT_EQ(json_url, json_resp.url);
+    EXPECT_EQ(std::string{"application/json"}, json_resp.header["content-type"]);
+    EXPECT_EQ(200, json_resp.status_code);
+    EXPECT_EQ(ErrorCode::OK, json_resp.error.code);
+
+    EXPECT_EQ(std::string{}, notfound_resp.text);
+    EXPECT_EQ(notfound_url, notfound_resp.url);
+    EXPECT_EQ(std::string{"text/plain"}, notfound_resp.header["content-type"]);
+    EXPECT_EQ(404, notfound_resp.status_code);
+    EXPECT_EQ(ErrorCode::OK, notfound_resp.error.code);
+
+    EXPECT_EQ(std::string{}, digest_resp.text);
+    EXPECT_EQ(digest_url, digest_resp.url);
+    EXPECT_EQ(std::string{"text/html"}, digest_resp.header["content-type"]);
+    EXPECT_EQ(200, digest_resp.status_code);
+    EXPECT_EQ(ErrorCode::OK, digest_resp.error.code);
+}
+
+TEST(MultiAsyncBasicTests, MultiAsyncOptionsTest) {
+    const std::string server_base{server->GetBaseUrl()};
+    const Url root_url{server_base + "/"};
+    const Url hello_url{server_base + "/hello.html"};
+
+    std::vector<AsyncResponseC> resps{MultiOptionsAsync(std::tuple{root_url}, std::tuple{hello_url})};
+
+    Response root_resp{resps.at(0).get()};
+    Response hello_resp{resps.at(1).get()};
+
+    EXPECT_EQ(std::string{}, root_resp.text);
+    EXPECT_EQ(root_url, root_resp.url);
+    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"}, root_resp.header["Access-Control-Allow-Methods"]);
+    EXPECT_EQ(200, root_resp.status_code);
+    EXPECT_EQ(ErrorCode::OK, root_resp.error.code);
+
+    EXPECT_EQ(std::string{}, hello_resp.text);
+    EXPECT_EQ(hello_url, hello_resp.url);
+    EXPECT_EQ(std::string{"GET, POST, PUT, DELETE, PATCH, OPTIONS"}, hello_resp.header["Access-Control-Allow-Methods"]);
+    EXPECT_EQ(200, hello_resp.status_code);
+    EXPECT_EQ(ErrorCode::OK, hello_resp.error.code);
+}
+
+TEST(MultiAsyncBasicTests, MultiAsyncPatchTest) {
+    const std::string server_base{server->GetBaseUrl()};
+    const Url patch_url{server_base + "/patch.html"};
+    const Url patch_not_allowed_url{server_base + "/patch_unallowed.html"};
+    const Payload pl{{"x", "10"}, {"y", "1"}};
+    const std::string expected_text{
+            "{\n"
+            "  \"x\": 10,\n"
+            "  \"y\": 1,\n"
+            "  \"sum\": 11\n"
+            "}"};
+    const std::string notallowed_text{"Method Not Allowed"};
+    std::vector<AsyncResponseC> resps{MultiPatchAsync(
+            std::tuple{patch_url, pl},
+            std::tuple{patch_not_allowed_url, pl}
+            )};
+    const Response success{resps.at(0).get()};
+    const Response fail{resps.at(1).get()};
+    EXPECT_EQ(expected_text, success.text);
+    EXPECT_EQ(200, success.status_code);
+    EXPECT_EQ(patch_url, success.url);
+
+    EXPECT_EQ(notallowed_text, fail.text);
+    EXPECT_EQ(405, fail.status_code);
+    EXPECT_EQ(ErrorCode::OK, fail.error.code);
+}
+
+TEST(MultiAsyncBasicTests, MultiAsyncPostTest) {
+    const std::string server_base{server->GetBaseUrl()};
+    const Url post_url{server_base + "/url_post.html"};
+    const Url form_post_url{server_base + "/form_post.html"};
+
+    const Payload post_data{{"x", "5"}, {"y", "15"}};
+    const Multipart form_data{{"x", 5}};
+
+    const std::string post_text{
+             "{\n"
+            "  \"x\": 5,\n"
+            "  \"y\": 15,\n"
+            "  \"sum\": 20\n"
+            "}"
+    };
+    const std::string form_text{
+            "{\n"
+            "  \"x\": \"5\"\n"
+            "}"
+    };
+
+    std::vector<AsyncResponseC> resps{MultiPostAsync(std::tuple{post_url, post_data}, std::tuple{form_post_url, form_data})};
+
+    Response post_resp{resps.at(0).get()};
+    Response form_resp{resps.at(1).get()};
+
+    EXPECT_EQ(post_text, post_resp.text);
+    EXPECT_EQ(post_url, post_resp.url);
+    EXPECT_EQ(std::string{"application/json"}, post_resp.header["content-type"]);
+    EXPECT_EQ(201, post_resp.status_code);
+    EXPECT_EQ(ErrorCode::OK, post_resp.error.code);
+
+    EXPECT_EQ(form_text, form_resp.text);
+    EXPECT_EQ(form_post_url, form_resp.url);
+    EXPECT_EQ(std::string{"application/json"}, form_resp.header["content-type"]);
+    EXPECT_EQ(201, form_resp.status_code);
+    EXPECT_EQ(ErrorCode::OK, form_resp.error.code);
+
+}
+
+TEST(MultiAsyncBasicTests, MultiAsyncPutTest) {
+    const std::string server_base{server->GetBaseUrl()};
+    const Url put_url{server_base + "/put.html"};
+    const Url put_failure_url{server_base + "/put_unallowed.html"};
+    const Payload pl{{"x", "7"}};
+    const std::string success_text{
+            "{\n"
+            "  \"x\": 7\n"
+            "}"
+    };
+    const std::string failure_text{"Method Not Allowed"};
+
+    std::vector<AsyncResponseC> resps{MultiPutAsync(std::tuple{put_url, pl}, std::tuple{put_failure_url, pl})};
+    Response success_resp{resps.at(0).get()};
+    Response failure_resp{resps.at(1).get()};
+
+    EXPECT_EQ(success_text, success_resp.text);
+    EXPECT_EQ(put_url, success_resp.url);
+    EXPECT_EQ(std::string{"application/json"}, success_resp.header["content-type"]);
+    EXPECT_EQ(200, success_resp.status_code);
+    EXPECT_EQ(ErrorCode::OK, success_resp.error.code);
+
+    EXPECT_EQ(failure_text, failure_resp.text);
+    EXPECT_EQ(put_failure_url, failure_resp.url);
+    EXPECT_EQ(std::string{"text/plain"}, failure_resp.header["content-type"]);
+    EXPECT_EQ(405, failure_resp.status_code);
+    EXPECT_EQ(ErrorCode::OK, failure_resp.error.code);
+}
+
 /**
  * We test that cancellation on queue, works, ie libcurl does not get engaged at all
  * To do this, we plant an observer function in the progress call sequence, which
@@ -39,6 +240,7 @@ TEST(MultiAsyncBasicTests, MultiAsyncGetTest) {
  */
 TEST(MultiAsyncCancelTests, CancellationOnQueue) {
     const Url hello_url{server->GetBaseUrl() + "/hello.html"};
+
     std::atomic_bool was_called{false};
     const std::function observer_fn{[&was_called]
             (cpr_pf_arg_t, cpr_pf_arg_t, cpr_pf_arg_t, cpr_pf_arg_t, intptr_t) -> bool {
@@ -48,7 +250,7 @@ TEST(MultiAsyncCancelTests, CancellationOnQueue) {
     };
 
     GlobalThreadPool::GetInstance()->Pause();
-    std::vector resps{MultiGetAsync(std::tuple{hello_url, ProgressCallback{observer_fn}})};
+    std::vector<AsyncResponseC> resps{MultiGetAsync(std::tuple{hello_url, ProgressCallback{observer_fn}})};
     EXPECT_EQ(CancellationResult::success, resps.at(0).cancel());
     GlobalThreadPool::GetInstance()->Resume();
 
@@ -77,7 +279,7 @@ TEST(MultiAsyncCancelTests, TestCancellationInTransit) {
             return true;
         }
     };
-    std::vector res{cpr::MultiGetAsync(std::tuple{call_url, cpr::ProgressCallback{observer_fn}})};
+    std::vector<AsyncResponseC> res{cpr::MultiGetAsync(std::tuple{call_url, cpr::ProgressCallback{observer_fn}})};
     is_called.wait(setup_lock);
     EXPECT_LT(0, counter);
     EXPECT_EQ(cpr::CancellationResult::success, res.at(0).cancel());
@@ -98,30 +300,28 @@ TEST(MultiAsyncCancelTests, TestCancellationInTransit) {
  * least on scheduler behaviour. We have tried, however, to set a boundary that
  * is permissive enough to ensure consistency.
  */
+
 TEST(MultiAsyncCancelTests, TestIntervalOfProgressCallsLowSpeed) {
     const Url call_url{server->GetBaseUrl() + "/low_speed_bytes.html"};
 
-    const size_t N{15};
-
+    size_t N{15};
     // This variable will be used to cancel the transaction at the point of the Nth call.
     std::atomic_size_t counter{0};
     const std::chrono::time_point start{std::chrono::steady_clock::now()};
 
-    const std::function observer_fn{[&counter, &N]
+    const std::function observer_fn{[&counter, N]
             (cpr_pf_arg_t, cpr_pf_arg_t, cpr_pf_arg_t, cpr_pf_arg_t, intptr_t) -> bool {
-                counter++;
-                return counter < N;
+                const size_t current_iteration{++counter}; // to avoid copy elision on return statement
+                return current_iteration < N;
             }
     };
 
-    std::vector resp{MultiGetAsync(std::tuple{call_url, ProgressCallback{observer_fn}})};
+    std::vector<AsyncResponseC> resp{MultiGetAsync(std::tuple{call_url, ProgressCallback{observer_fn}})};
     resp.at(0).wait();
 
     const std::chrono::duration elapsed_time{std::chrono::steady_clock::now() - start};
     EXPECT_GT(std::chrono::seconds(N), elapsed_time);
 }
-
-
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/multiasync_tests.hpp
+++ b/test/multiasync_tests.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <gtest/gtest.h>
+
+class TestSynchronizationEnv : public testing::Environment {
+  public:
+    std::atomic_size_t counter{0};
+    std::atomic_bool fn_called{false};
+    std::condition_variable test_cv{};
+    std::mutex test_cv_mutex{};
+
+    void Reset() {
+        counter = 0;
+        fn_called = false;
+    }
+};


### PR DESCRIPTION
Here we aim to create an extension of the `cpr` API that introduces multiple, asynchronous, cancellable requests, an asynchronous analogue to the existing `MultiGet` etc. part of the API.
Internally, it is implemented using `cpr`'s `ThreadPool` infrastructure. The creation of the appropriate tests is also in progress.
Aims to close issue #257 , and the development follows the oultine discussed in the issue's comments.