### PR TITLE
Fixed thread pool not creating enough new threads after awhile

### DIFF
--- a/cpr/threadpool.cpp
+++ b/cpr/threadpool.cpp
@@ -100,9 +100,9 @@ bool ThreadPool::CreateThread() {
             if (task) {
                 task();
                 ++idle_thread_num;
-            } else if (initialRun) {
-                ++idle_thread_num;
-                initialRun = false;
+                if (initialRun) {
+                    initialRun = false;
+                }
             }
         }
     });


### PR DESCRIPTION
1. `InitialRun` will never be false, so `idle_thread_num` will only be decremented once when deleting threads. As the tasks progress, `idle_thread_num` will increase, which will result in the inability to create new threads;
2. Because `idle_thread_num` is size_t type, so it is unnecessary to judge whether it is less than 0;

Thank you very much for this project. I hope my fix is correct.