### PR TITLE
fix error: using typedef-name ‘curl_mime’ after ‘struct’ (#892)

### DIFF
--- a/include/cpr/curlholder.h
+++ b/include/cpr/curlholder.h
@@ -28,7 +28,7 @@ struct CurlHolder {
     CURL* handle{nullptr};
     struct curl_slist* chunk{nullptr};
     struct curl_slist* resolveCurlList{nullptr};
-    struct curl_mime* multipart{nullptr};
+    curl_mime* multipart{nullptr};
     std::array<char, CURL_ERROR_SIZE> error{};
 
     CurlHolder();


### PR DESCRIPTION
we already have previous declaration of ‘curl_mime’ in curl.h: typedef struct curl_mime_s curl_mime;