### PR TITLE
initial cpack implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,3 +378,5 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND CPR_BUILD_TESTS)
     add_subdirectory(test)
     restore_variable(DESTINATION CMAKE_CXX_CLANG_TIDY BACKUP CMAKE_CXX_CLANG_TIDY_BKP)
 endif()
+
+include(cmake/cpack.cmake)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ add_executable(your_target_name your_target_name.cpp)
 target_link_libraries(your_target_name PRIVATE cpr::cpr)
 ```
 
+#### CPack
+You may also use cpack to generate a Debian package after building with:
+```Bash
+$ cpack -G DEB
+```
+
 ### Bazel
 
 Please refer to [hedronvision/bazel-make-cc-https-easy](https://github.com/hedronvision/bazel-make-cc-https-easy).

--- a/cmake/cpack.cmake
+++ b/cmake/cpack.cmake
@@ -1,0 +1,23 @@
+set(CPACK_PACKAGE_NAME "libcpr")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "C++ Requests: Curl for People")
+set(CPACK_PACKAGE_DESCRIPTION "C++ Requests is a simple wrapper around [libcurl](http://curl.haxx.se/libcurl) inspired by the excellent [Python Requests](https://github.com/kennethreitz/requests) project.")
+set(CPACK_PACKAGE_VENDOR "libcpr")
+set(CPACK_PACKAGE_CONTACT "Adam Aposhian <aposhian.dev@gmail.com>")
+set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
+set(CPACK_SOURCE_GENERATOR "TBZ2")
+set(CPACK_PACKAGE_VERSION_MAJOR ${cpr_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${cpr_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${cpr_VERSION_PATCH})
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "libcpr-${cpr_VERSION}")
+
+set(CPACK_SOURCE_IGNORE_FILES
+  "/\\\\.git"
+  "/\\\\.github"
+  "/debian/"
+  "/.*build-.*/"
+  ${PROJECT_BINARY_DIR}
+  )
+
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+
+include(CPack)


### PR DESCRIPTION
Addresses #894.

This adds a very simple cpack implementation, supporting debian and source (non-distro specific) generators so far.

Adding RPM support is probably trivial, but I just need to test what additional vars need to be set.

@COM8 I figure the package contact should probably be you, but I don't know what contact email to put. I've also seen packages where the debian maintainer is listed here, not necessarily the upstream maintainer. So not exactly sure on that.