### PR TITLE
NuGet: Fix VS2022 compatibility

### DIFF
--- a/nuget/build/native/libcpr.props
+++ b/nuget/build/native/libcpr.props
@@ -17,11 +17,8 @@
   </ItemGroup>
   <PropertyGroup>
     <CprLibraries>@(CprLibs)</CprLibraries>
-    </PropertyGroup>
-    <ItemDefinitionGroup>
-    <ClCompile>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)\$(Platform)\$(Configuration)\include</AdditionalIncludeDirectories>
-    </ClCompile>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies>$(CprLibraries);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/nuget/build/native/libcpr.targets
+++ b/nuget/build/native/libcpr.targets
@@ -3,4 +3,9 @@
   <Target Name="PlatformCheck" BeforeTargets="InjectReference" Condition="(('$(Platform)' != 'x86') AND ('$(Platform)' != 'x64')) AND ('$(Platform)' != 'Win32'))">
     <Error  Text="$(MSBuildThisFileName) does not work correctly on this platform: '$(Platform)'. You need to specify platform x86, x64, or Win32." />
   </Target>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)\$(Platform)\$(Configuration)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
- Move AdditionalIncludeDirectories section from libcpr.props to libcpr.targets. 
- Add %(AdditionalIncludeDirectories). 
- Minor cleanup of line indentation in libcpr.probs.

This fixes my issue https://github.com/libcpr/cpr/issues/902 in Visual Studio 2022 Version 17.5.5.
However I have not tested any other environments. 