### PR TITLE
[WIP] Nuget Tag Name Fix

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -5,9 +5,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The semantic version number'
-        required: true
-        type: environment
+        description: 'The optional semantic version number. If not supplied the branch/tag will be used.'
+        type: string
 
 jobs:
   package-windows-latest:

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -12,14 +12,14 @@ jobs:
   package-windows-latest:
     runs-on: windows-latest
     steps:
-    - name: Set version
+    - name: Set version based on input
       if: ${{ inputs.version }}
       run: echo "RELEASE_VERSION=${{ inputs.version }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-    - name: Set env
+    - name: Set version based on ref
       if: ${{ !inputs.version }}
       run: echo "RELEASE_VERSION=$($env:GITHUB_REF -replace 'refs/.*/', '')" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
     - name: Print Version
-      run: echo "XXX VERSION ${{ env.RELEASE_VERSION }}"
+      run: echo "NuGet version will be '${{ env.RELEASE_VERSION }}'"
     - name: Checkout
       uses: actions/checkout@v3
       with:
@@ -92,8 +92,6 @@ jobs:
         install-options: --prefix ${{github.workspace}}\install --config Debug
     - name: "[Debug_x64] Copy install files for Debug_x64"
       run: xcopy /e /i /y ${{github.workspace}}\install ${{github.workspace}}\nuget\build\native\x64\Debug
-    - name: Set env
-      run: echo "RELEASE_VERSION=$($env:GITHUB_REF -replace 'refs/.*/', '')" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
     - name: "Copy Readme.md"
       run: xcopy /y ${{github.workspace}}\README.md ${{github.workspace}}\nuget
     - name: "Create NuGet package"
@@ -106,7 +104,7 @@ jobs:
       with:
         name: artifact-nuget
         path: ${{github.workspace}}\*.nupkg
-    # - name: "Publish package to NuGet.org"
-    #   env:
-    #     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-    #   run: nuget push ${{github.workspace}}\*.nupkg $ENV:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json
+    - name: "Publish package to NuGet.org"
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: nuget push ${{github.workspace}}\*.nupkg $ENV:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -94,7 +94,7 @@ jobs:
       with:
         name: artifact-nuget
         path: ${{github.workspace}}\*.nupkg
-    - name: "Publish package to NuGet.org"
-      env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: nuget push ${{github.workspace}}\*.nupkg $ENV:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json
+    # - name: "Publish package to NuGet.org"
+    #   env:
+    #     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    #   run: nuget push ${{github.workspace}}\*.nupkg $ENV:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -7,6 +7,10 @@ on:
       version:
         description: 'The optional semantic version number. If not supplied the branch/tag will be used.'
         type: string
+      no_publish:
+          description: 'Prevent publishing the NuGet package. Just build it and then upload it as an artifact.'
+          type: boolean
+          default: false
 
 jobs:
   package-windows-latest:
@@ -105,6 +109,7 @@ jobs:
         name: artifact-nuget
         path: ${{github.workspace}}\*.nupkg
     - name: "Publish package to NuGet.org"
+      if: ${{ !inputs.no_publish }}
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: nuget push ${{github.workspace}}\*.nupkg $ENV:NUGET_API_KEY -Source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -2,6 +2,7 @@ name: Build NuGet Package
 on:
   push:
     tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
+  workflow_dispatch:
 
 jobs:
   package-windows-latest:
@@ -79,17 +80,13 @@ jobs:
         install-options: --prefix ${{github.workspace}}\install --config Debug
     - name: "[Debug_x64] Copy install files for Debug_x64"
       run: xcopy /e /i /y ${{github.workspace}}\install ${{github.workspace}}\nuget\build\native\x64\Debug
-    - name: "Get latest release tag"
-      uses: oprypin/find-latest-tag@v1
-      with:
-        repository: libcpr/cpr
-        releases-only: true
-      id: find_release_tag
+    - name: Set env
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: "Copy Readme.md"
       run: xcopy /y ${{github.workspace}}\README.md ${{github.workspace}}\nuget
     - name: "Create NuGet package"
       env: 
-        VERSION: ${{ steps.find_release_tag.outputs.tag }}
+        VERSION: ${{ env.RELEASE_VERSION }}
         COMMIT_HASH: ${{ github.sha }}
       run: nuget pack ${{github.workspace}}\nuget\libcpr.nuspec -OutputDirectory ${{github.workspace}} -Properties "VERSION=$ENV:VERSION;COMMIT_HASH=$ENV:COMMIT_HASH"
     - name: "Upload artifact"

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -2,9 +2,6 @@ name: Build NuGet Package
 on:
   push:
     tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
-  pull_request:
-    tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
-  workflow_dispatch:
 
 jobs:
   package-windows-latest:

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -8,6 +8,10 @@ jobs:
   package-windows-latest:
     runs-on: windows-latest
     steps:
+    - name: Print
+      run: echo "RELEASE_VERSION=$($env:GITHUB_REF -replace 'refs/.*/', '')"
+    - name: Set env
+      run: echo "RELEASE_VERSION=$($env:GITHUB_REF -replace 'refs/.*/', '')" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
     - name: Checkout
       uses: actions/checkout@v3
       with:
@@ -81,7 +85,7 @@ jobs:
     - name: "[Debug_x64] Copy install files for Debug_x64"
       run: xcopy /e /i /y ${{github.workspace}}\install ${{github.workspace}}\nuget\build\native\x64\Debug
     - name: Set env
-      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=$($env:GITHUB_REF -replace 'refs/.*/', '')" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
     - name: "Copy Readme.md"
       run: xcopy /y ${{github.workspace}}\README.md ${{github.workspace}}\nuget
     - name: "Create NuGet package"

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -3,15 +3,24 @@ on:
   push:
     tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'The semantic version number'
+        required: true
+        type: environment
 
 jobs:
   package-windows-latest:
     runs-on: windows-latest
     steps:
-    - name: Print
-      run: echo "RELEASE_VERSION=$($env:GITHUB_REF -replace 'refs/.*/', '')"
+    - name: Set version
+      if: ${{ inputs.version }}
+      run: echo "RELEASE_VERSION=${{ inputs.version }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
     - name: Set env
+      if: ${{ !inputs.version }}
       run: echo "RELEASE_VERSION=$($env:GITHUB_REF -replace 'refs/.*/', '')" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+    - name: Print Version
+      run: echo "XXX VERSION ${{ env.RELEASE_VERSION }}"
     - name: Checkout
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Let's say we are releasing a hotfix version for 1.9.x but there exists already a version 1.10.x. Then the NuGet CI will create a new NuGet package for 1.10.x instead of 1.9.x.
This PR resolves that. 