### PR TITLE
Removed the tag specific trigger for deb CI packages

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -3,7 +3,6 @@ on:
   push:
       tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
   pull_request:
-      tags: [ '[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   package-ubuntu-latest-amd64:


### PR DESCRIPTION
Removes the invalid `tags` attribute for the `pull_request` deb build CI run.