### PR TITLE
Add vector<Part> param to Multipart initialization

### DIFF
--- a/cpr/multipart.cpp
+++ b/cpr/multipart.cpp
@@ -3,4 +3,5 @@
 namespace cpr {
 Multipart::Multipart(const std::initializer_list<Part>& p_parts) : parts{p_parts} {}
 Multipart::Multipart(const std::vector<Part>& p_parts) : parts{p_parts} {}
+Multipart::Multipart(const std::vector<Part>&& p_parts) : parts{p_parts} {}
 } // namespace cpr

--- a/cpr/multipart.cpp
+++ b/cpr/multipart.cpp
@@ -2,4 +2,5 @@
 
 namespace cpr {
 Multipart::Multipart(const std::initializer_list<Part>& p_parts) : parts{p_parts} {}
+Multipart::Multipart(const std::vector<Part>& p_parts) : parts{p_parts} {}
 } // namespace cpr

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -34,6 +34,7 @@ struct Part {
 class Multipart {
   public:
     Multipart(const std::initializer_list<Part>& parts);
+    Multipart(const std::vector<Part>& parts);
 
     std::vector<Part> parts;
 };

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -35,6 +35,7 @@ class Multipart {
   public:
     Multipart(const std::initializer_list<Part>& parts);
     Multipart(const std::vector<Part>& parts);
+    Multipart(const std::vector<Part>&& parts);
 
     std::vector<Part> parts;
 };

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -618,6 +618,24 @@ TEST(MultipartTests, SetMultipartValueTest) {
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 
+TEST(MultipartTests, SetMultipartVectorPartsTest) {
+    Url url{server->GetBaseUrl() + "/form_post.html"};
+    Session session;
+    session.SetUrl(url);
+    Multipart multipart{std::vector<Part>{Part{"x", "5"}}};
+    session.SetMultipart(multipart);
+    Response response = session.Post();
+    std::string expected_text{
+            "{\n"
+            "  \"x\": \"5\"\n"
+            "}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 TEST(BodyTests, SetBodyTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
     Session session;


### PR DESCRIPTION
Adds `std::vector<Part>` parameter support to `Multipart` initialization. The change allows us to construct the Multipart dynamically by adding the `Part` selectively and pass the vector to `Multipart`.