### PR TITLE
Allow disabling the 'Accept-Encoding' header

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -138,8 +138,11 @@ void Session::prepareCommon() {
 
 #if LIBCURL_VERSION_NUM >= 0x072100
     if (acceptEncoding_.empty()) {
-        /* enable all supported built-in compressions */
+        // Enable all supported built-in compressions
         curl_easy_setopt(curl_->handle, CURLOPT_ACCEPT_ENCODING, "");
+    } else if (acceptEncoding_.disabled()) {
+        // Disable curl adding the 'Accept-Encoding' header
+        curl_easy_setopt(curl_->handle, CURLOPT_ACCEPT_ENCODING, nullptr);
     } else {
         curl_easy_setopt(curl_->handle, CURLOPT_ACCEPT_ENCODING, acceptEncoding_.getString().c_str());
     }

--- a/include/cpr/accept_encoding.h
+++ b/include/cpr/accept_encoding.h
@@ -5,7 +5,7 @@
 #include <initializer_list>
 #include <map>
 #include <string>
-#include <vector>
+#include <unordered_set>
 
 namespace cpr {
 
@@ -14,21 +14,26 @@ enum class AcceptEncodingMethods {
     deflate,
     zlib,
     gzip,
+    disabled,
 };
 
-static const std::map<AcceptEncodingMethods, std::string> AcceptEncodingMethodsStringMap{{AcceptEncodingMethods::identity, "identity"}, {AcceptEncodingMethods::deflate, "deflate"}, {AcceptEncodingMethods::zlib, "zlib"}, {AcceptEncodingMethods::gzip, "gzip"}};
+// NOLINTNEXTLINE(cert-err58-cpp)
+static const std::map<AcceptEncodingMethods, std::string> AcceptEncodingMethodsStringMap{{AcceptEncodingMethods::identity, "identity"}, {AcceptEncodingMethods::deflate, "deflate"}, {AcceptEncodingMethods::zlib, "zlib"}, {AcceptEncodingMethods::gzip, "gzip"}, {AcceptEncodingMethods::disabled, "disabled"}};
 
 class AcceptEncoding {
   public:
     AcceptEncoding() = default;
+    // NOLINTNEXTLINE(google-explicit-constructor)
     AcceptEncoding(const std::initializer_list<AcceptEncodingMethods>& methods);
+    // NOLINTNEXTLINE(google-explicit-constructor)
     AcceptEncoding(const std::initializer_list<std::string>& methods);
 
-    bool empty() const noexcept;
-    const std::string getString() const;
+    [[nodiscard]] bool empty() const noexcept;
+    [[nodiscard]] const std::string getString() const;
+    [[nodiscard]] bool disabled() const;
 
   private:
-    std::vector<std::string> methods_;
+    std::unordered_set<std::string> methods_;
 };
 
 } // namespace cpr


### PR DESCRIPTION
Resolves #925

Adds a new value for `AcceptEncoding`: `disabled`. When a user passes this value to a `AcceptEncoding` object it will prevent curl from creating a `Accept-Encoding`.

It has the same behaviour as passing `NULL` to the curl option [`CURLOPT_ACCEPT_ENCODING`](https://curl.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html).

When passing multiple values to `AcceptEncoding` including `disabled`, an exception of type `std::invalid_argument` get thrown when performing a request.

### Examples

````c++
cpr::Session session;
session.SetUrl("https://example.com");
session.SetAcceptEncoding({AcceptEncodingMethods::disabled}); // Disable setting the `Accept-Encoding` headder
Response response = session.Get();
```` 

````c++
cpr::Session session;
session.SetUrl("https://example.com");
session.SetAcceptEncoding({"disabled"}); // Disable setting the `Accept-Encoding` headder
Response response = session.Get();
```` 

````c++
cpr::Session session;
session.SetUrl("https://example.com");
session.SetAcceptEncoding({AcceptEncodingMethods::disabled, AcceptEncodingMethods::deflate});
Response response = session.Get(); // An exception of type  `std::invalid_argument` will be thrown here since multiple values are passed to `AcceptEncoding` where one of them is `disabled`
```` 