### PR TITLE
boost/filesystem: use version 4 for compatibility with std::filesystem

### DIFF
--- a/include/cpr/filesystem.h
+++ b/include/cpr/filesystem.h
@@ -3,6 +3,7 @@
 
 // Include filesystem into the namespace "fs" from either "filesystem" or "experimental/filesystem" or "boost/filesystem"
 #ifdef CPR_USE_BOOST_FILESYSTEM
+#define BOOST_FILESYSTEM_VERSION 4 // Use the latest, with the closest behavior to std::filesystem.
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
 // cppcheck-suppress preprocessorErrorDirective


### PR DESCRIPTION
Hello again, @COM8,

I was messing around some more with similar backporting of std::filesystem with boost::filesystem in another project--and I was thinking: Might it make sense to move over to boost filesystem v4?

The advantage of using the newer api (rather than the older one, v3) is that it's more similar to std::filesystem, removing some potential future foot guns if we're just using it as a backport. ([Docs.](https://www.boost.org/doc/libs/1_82_0/libs/filesystem/doc/v4.html))

Thanks for being great!
Chris

