### PR TITLE
Avoid conflicts with external components

### DIFF
--- a/include/cpr/filesystem.h
+++ b/include/cpr/filesystem.h
@@ -5,14 +5,20 @@
 #ifdef CPR_USE_BOOST_FILESYSTEM
 #define BOOST_FILESYSTEM_VERSION 4 // Use the latest, with the closest behavior to std::filesystem.
 #include <boost/filesystem.hpp>
+namespace cpr {
 namespace fs = boost::filesystem;
+}
 // cppcheck-suppress preprocessorErrorDirective
 #elif __has_include(<filesystem>)
 #include <filesystem>
+namespace cpr {
 namespace fs = std::filesystem;
+}
 #elif __has_include("experimental/filesystem")
 #include <experimental/filesystem>
+namespace cpr {
 namespace fs = std::experimental::filesystem;
+}
 #else
 #error "Failed to include <filesystem> header!"
 #endif


### PR DESCRIPTION
Global namespace alias might cause conflicts with external components. I specifically hit this issue when writing tests for a daemon which uses this library.