### PR TITLE
Add ZLIB::ZLIB alias and conditional renaming

### DIFF
--- a/cmake/zlib_external.cmake
+++ b/cmake/zlib_external.cmake
@@ -14,8 +14,10 @@ FetchContent_Declare(zlib
                     USES_TERMINAL_DOWNLOAD TRUE)
 FetchContent_MakeAvailable(zlib)
 
+add_library(ZLIB::ZLIB ALIAS zlib)
+
 # Fix Windows zlib dll names from "zlibd1.dll" to "zlib.dll":
-if(WIN32)
+if(WIN32 AND BUILD_SHARED_LIBS)
     set_target_properties(zlib PROPERTIES OUTPUT_NAME "zlib")
     set_target_properties(zlib PROPERTIES DEBUG_POSTFIX "")
     set_target_properties(zlib PROPERTIES SUFFIX ".dll")


### PR DESCRIPTION
Hi :)

This pull request aims to fix the static zlib being renamed to zlib.dll when it should remain a .lib.
It also ads the ZLIB::ZLIB alias that curl tries to link to.