### PR TITLE
Fix dangling reference to callback after move

### DIFF
--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -239,16 +239,22 @@ class Session : public std::enable_shared_from_this<Session> {
     ProxyAuthentication proxyAuth_;
     Header header_;
     AcceptEncoding acceptEncoding_;
-    /**
-     * Will be set by the read callback.
-     * Ensures that the "Transfer-Encoding" is set to "chunked", if not overriden in header_.
-     **/
-    ReadCallback readcb_;
-    HeaderCallback headercb_;
-    WriteCallback writecb_;
-    ProgressCallback progresscb_;
-    DebugCallback debugcb_;
-    CancellationCallback cancellationcb_;
+
+
+    struct Callbacks {
+        /**
+         * Will be set by the read callback.
+         * Ensures that the "Transfer-Encoding" is set to "chunked", if not overriden in header_.
+         **/
+        ReadCallback readcb_;
+        HeaderCallback headercb_;
+        WriteCallback writecb_;
+        ProgressCallback progresscb_;
+        DebugCallback debugcb_;
+        CancellationCallback cancellationcb_;
+    };
+
+    std::unique_ptr<Callbacks> cbs_{std::make_unique<Callbacks>()};
 
     size_t response_string_reserve_size_{0};
     std::string response_string_;

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -1547,6 +1547,18 @@ TEST(CallbackTests, PatchCallbackTest) {
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 
+TEST(CallbackTests, Move) {
+    auto session = Session();
+    session.SetDebugCallback(DebugCallback([](auto, auto, auto) {}));
+
+    auto use = +[](Session s) {
+        s.SetUrl(server->GetBaseUrl());
+        s.Get();
+    };
+    use(std::move(session));
+}
+
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(server);


### PR DESCRIPTION
I initially tried a wrapper object for the callbacks but callbacks have dependencies between each others so a unique_ptr
was much simpler.