### PR TITLE
Util Method to Parse Raw Cookie Strings

### DIFF
--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -14,6 +14,7 @@ namespace cpr::util {
 
 Header parseHeader(const std::string& headers, std::string* status_line = nullptr, std::string* reason = nullptr);
 Cookies parseCookies(curl_slist* raw_cookies);
+Cookie parseCookie(const std::string& raw_cookie);
 size_t readUserFunction(char* ptr, size_t size, size_t nitems, const ReadCallback* read);
 size_t headerUserFunction(char* ptr, size_t size, size_t nmemb, const HeaderCallback* header);
 size_t writeFunction(char* ptr, size_t size, size_t nmemb, std::string* data);


### PR DESCRIPTION
As discussed via [gitter](https://app.gitter.im/#/room/#libcpr_community:gitter.im?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) a option to parse raw cookie strings would be awesome in a context of [Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) Headers.