### PR TITLE
Fixed curl multi reuse after free

### DIFF
--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -1,6 +1,7 @@
 #include "cpr/multiperform.h"
 
 #include "cpr/interceptor.h"
+#include "cpr/multipart.h"
 #include "cpr/response.h"
 #include "cpr/session.h"
 #include <algorithm>
@@ -16,6 +17,13 @@ MultiPerform::~MultiPerform() {
     // Unlock all sessions
     for (const std::pair<std::shared_ptr<Session>, HttpMethod>& pair : sessions_) {
         pair.first->isUsedInMultiPerform = false;
+
+        // Remove easy handle from multi handle
+        const CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, pair.first->curl_->handle);
+        if (error_code) {
+            std::cerr << "curl_multi_remove_handle() failed, code " << static_cast<int>(error_code) << std::endl;
+            return;
+        }
     }
 }
 


### PR DESCRIPTION
Cleaning up the `CURLM` was not done correctly and therefore produced a reuse after free caught by the address sanitizer 🎉.

The correct way for cleaning is available here: https://curl.se/libcurl/c/curl_multi_cleanup.html