### PR TITLE
Modify the boost version to be >= 1.77

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -54,7 +54,7 @@ target_sources(cpr PRIVATE
 
 # Filesystem
 if(CPR_USE_BOOST_FILESYSTEM)
-  find_package(Boost 1.44 REQUIRED COMPONENTS filesystem)
+  find_package(Boost 1.77 REQUIRED COMPONENTS filesystem)
   if(Boost_FOUND)
     target_link_libraries(cpr PUBLIC Boost::filesystem)
   endif()


### PR DESCRIPTION
This commit https://github.com/libcpr/cpr/pull/929 Add one line: `#define BOOST_FILESYSTEM_VERSION 4`

According to boost [changelog 1.77](https://www.boost.org/users/history/version_1_77_0.html), version 4 was introduced in version boost 1.77.

> Users can select Boost.Filesystem version by defining BOOST_FILESYSTEM_VERSION macro to either 3 or 4 when compiling their code.

But cpr looks for boost >= 1.44

https://github.com/libcpr/cpr/blob/6b3e3531d3e5781b4b19e7cf64ed76035bf59d37/include/CMakeLists.txt#L55-L61

On macOS 14, install the latest boost through homebrew, and with anaconda installed. CPR will incorrectly link boost (1.73) within anaconda during compilation, and report error:

> Compiling Filesystem version 3 file with BOOST_FILESYSTEM_VERSION defined != 3