### PR TITLE
only set CURLSSLOPT_NATIVE_CA if curl version >= 7.71.0

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -163,8 +163,10 @@ void Session::prepareCommon() {
     const bool noRevoke = bitmask & CURLSSLOPT_NO_REVOKE;
 #endif
 
+#if LIBCURL_VERSION_NUM >= 0x074700 // 7.71.0
     // Fix loading certs from Windows cert store when using OpenSSL:
     curl_easy_setopt(curl_->handle, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+#endif
 
 // Ensure SSL no revoke is still set
 #if SUPPORT_SSL_NO_REVOKE


### PR DESCRIPTION
only seems to be needed for windows and minimum curl version there is already checked in CMakeLists...

fixes #960