### PR TITLE
GitHub action for auto-updating GIT_TAG in readme

### DIFF
--- a/.github/workflows/readme-updater.yml
+++ b/.github/workflows/readme-updater.yml
@@ -1,0 +1,27 @@
+name: Update GIT_TAG In Readme
+on:
+  release:
+    types: [published]
+
+# Workflow configuration
+env:
+  OUTPUT_BRANCH: "master"
+  COMMIT_MESSAGE: "Update GIT_TAG on new release"
+
+jobs:
+  update-git-tag:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v3
+      with:
+        ref: ${{github.sha}}
+    - name: "Replace GIT_TAG"
+      run: sed -i -re 's/(GIT_TAG) [0-9a-f]+/\1 ${{github.sha}}/' README.md
+    - name: "Commit changes"
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: ${{env.COMMIT_MESSAGE}}
+        branch: ${{env.OUTPUT_BRANCH}}

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add the following to your `CMakeLists.txt`.
 ```cmake
 include(FetchContent)
 FetchContent_Declare(cpr GIT_REPOSITORY https://github.com/libcpr/cpr.git
-                         GIT_TAG 3b15fa82ea74739b574d705fea44959b58142eb8)
+                         GIT_TAG 3b15fa82ea74739b574d705fea44959b58142eb8) # Replace with your desired git commit from: https://github.com/libcpr/cpr/releases
 FetchContent_MakeAvailable(cpr)
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add the following to your `CMakeLists.txt`.
 ```cmake
 include(FetchContent)
 FetchContent_Declare(cpr GIT_REPOSITORY https://github.com/libcpr/cpr.git
-                         GIT_TAG 0817715923c9705e68994eb52ef9df3f6845beba) # The commit hash for 1.10.x. Replace with the latest from: https://github.com/libcpr/cpr/releases
+                         GIT_TAG 3b15fa82ea74739b574d705fea44959b58142eb8)
 FetchContent_MakeAvailable(cpr)
 ```
 


### PR DESCRIPTION
This workflow will be automatically launched on a published release.
It finds regex `(GIT_TAG) [0-9a-f]+` in README.md and replaces the git tag with the one which is relevant for the created release.

So basically the workflow will do something like this:
```diff
-                          GIT_TAG 0817715923c9705e68994eb52ef9df3f6845beba)
+                          GIT_TAG 3b15fa82ea74739b574d705fea44959b58142eb8)
```

This way there will be no need to update the tag manually and therefore repository users will not have to additionally verify latest release tag.

I have also replaced current `0817715923c9705e68994eb52ef9df3f6845beba` tag in readme with the most recent released `3b15fa82ea74739b574d705fea44959b58142eb8` so there is no need to create a new release once the changes are merged.

Note that the workflow uses third-party Action for committing changes: `stefanzweifel/git-auto-commit-action@v5`