### PR TITLE
`cpr::Session` Is Now Unmovable/Copyable

### DIFF
--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -54,11 +54,11 @@ class Session : public std::enable_shared_from_this<Session> {
   public:
     Session();
     Session(const Session& other) = delete;
-    Session(Session&& old) = default;
+    Session(Session&& old) = delete;
 
     ~Session() = default;
 
-    Session& operator=(Session&& old) noexcept = default;
+    Session& operator=(Session&& old) noexcept = delete;
     Session& operator=(const Session& other) = delete;
 
     void SetUrl(const Url& url);

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -1587,11 +1587,11 @@ TEST(CallbackTests, Move) {
     auto session = Session();
     session.SetDebugCallback(DebugCallback([](auto, auto, auto) {}));
 
-    auto use = +[](Session s) {
+    auto use = +[](Session& s) {
         s.SetUrl(server->GetBaseUrl());
         s.Get();
     };
-    use(std::move(session));
+    use(session);
 }
 
 


### PR DESCRIPTION
### Why?
`cpr::Session` is a complex object and while making it movable/copyable one has to keep all properties in mind. An easier solution would be to wrap `cpr::Session` inside for example a `std::shared_ptr` to allow it to be movable.

Copyable does not make sense since a curl session is not copyable in a useful way.
What should happen if you copy a `cpr::Session` in mids of a request? Should there be a new request with the same destination and the same connection state? This is not possible in a sensible way.

Fixes #990.