### PR TITLE
Fixed openssl/types.h include for ubuntu20.04

### DIFF
--- a/cpr/ssl_ctx.cpp
+++ b/cpr/ssl_ctx.cpp
@@ -17,8 +17,11 @@
 // openssl/types.h was added in later version of openssl and is therefore not always available.
 // This is for example the case on Ubuntu 20.04.
 // We try to include it if available to satisfy clang-tidy.
+// Ref: https://github.com/openssl/openssl/commit/50cd4768c6b89c757645f28519236bb989216f8d
 #if __has_include(<openssl/types.h>)
 #include <openssl/types.h>
+#else
+#include <openssl/ossl_typ.h>
 #endif
 
 namespace cpr {

--- a/cpr/ssl_ctx.cpp
+++ b/cpr/ssl_ctx.cpp
@@ -11,9 +11,15 @@
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
-#include <openssl/types.h>
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
+
+// openssl/types.h was added in later version of openssl and is therefore not always available.
+// This is for example the case on Ubuntu 20.04.
+// We try to include it if available to satisfy clang-tidy.
+#if __has_include(<openssl/types.h>)
+#include <openssl/types.h>
+#endif
 
 namespace cpr {
 


### PR DESCRIPTION
`openssl/types.h` was added in later version of openssl and is therefore not always available. This is for example the case on Ubuntu 20.04.
So we try to include it if available to satisfy clang-tidy.
