### PR TITLE
Reverted to actions/checkout@v3 to deal with old node versions

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         submodules: true
         path: cpr

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Print Version
       run: echo "NuGet version will be '${{ env.RELEASE_VERSION }}'"
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Setup NuGet.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         cmake-version: '3.22.x'
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CPR_BUILD_TESTS: ON
@@ -59,7 +59,7 @@ jobs:
       with:
         cmake-version: '3.22.x'
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CPR_BUILD_TESTS: ON
@@ -90,7 +90,7 @@ jobs:
       with:
         cmake-version: '3.22.x'
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CPR_BUILD_TESTS: ON
@@ -118,7 +118,7 @@ jobs:
     - name: Install Dependencies
       run: dnf install -y gcc clang git gcc gdb make openssl-devel libcurl-devel cmake
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CPR_BUILD_TESTS: ON
@@ -149,7 +149,7 @@ jobs:
     - name: Install Dependencies
       run: dnf install -y gcc clang git gcc gdb make openssl-devel libcurl-devel cmake
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CPR_BUILD_TESTS: ON
@@ -178,7 +178,7 @@ jobs:
     - name: Install Dependencies
       run: dnf install -y gcc clang git gcc gdb make openssl-devel libasan libubsan liblsan libtsan cmake
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CPR_BUILD_TESTS: ON
@@ -200,7 +200,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CMAKE_GENERATOR: "Visual Studio 17 2022"
@@ -220,7 +220,7 @@ jobs:
     - name: Install OpenSSL
       run: choco install openssl -y
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CMAKE_GENERATOR: "Visual Studio 17 2022"
@@ -247,7 +247,7 @@ jobs:
         export CPPFLAGS="-I/usr/local/opt/openssl@3/include"
         export PKG_CONFIG_PATH="/usr/local/opt/openssl@3/lib/pkgconfig"
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CPR_BUILD_TESTS: ON
@@ -272,7 +272,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CPR_BUILD_TESTS: ON
@@ -291,7 +291,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CPR_BUILD_TESTS: ON
@@ -318,7 +318,7 @@ jobs:
         echo 'export PATH="/usr/local/opt/openssl@3/bin:$PATH"' >> /Users/runner/.bash_profile
         source ~/.bash_profile
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "Build & Test"
       env:
         CPR_BUILD_TESTS: ON

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install clang-tidy
       run: sudo dnf install -y clang-tools-extra
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: Check format
       uses: RafikFarhad/clang-format-github-action@3.2.0
       with:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install clang-tidy
       run: sudo dnf install -y clang-tools-extra
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: "[Release g++] Build & Test"
       env:
         CPR_BUILD_TESTS: ON

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Update package list

--- a/.github/workflows/readme-updater.yml
+++ b/.github/workflows/readme-updater.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         ref: ${{github.sha}}
     - name: "Replace GIT_TAG"


### PR DESCRIPTION
Compiling with older versions of Ubuntu (e.g. 18.04) results in:
```
Run actions/checkout@v4
/usr/bin/docker exec  4567e21c9cc6600b4ad85f7a41819a3b13ac0ee1deff34facae87e11fddf53d6 sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```

Ref: https://github.com/actions/checkout/issues/1487

As a solution we revert back to v3 of `actions/checkout`.