### PR TITLE
Fixed download with cpr::AcceptEncoding

### DIFF
--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -269,7 +269,17 @@ class Session : public std::enable_shared_from_this<Session> {
     Response makeRequest();
     Response proceed();
     Response intercept();
+    /**
+     * Prepares the curl object for a request with everything used by all requests.
+     **/
+    void prepareCommonShared();
+    /**
+     * Prepares the curl object for a request with everything used by all non download related requests.
+     **/
     void prepareCommon();
+    /**
+     * Prepares the curl object for a request with everything used by the download request.
+     **/
     void prepareCommonDownload();
     void prepareHeader();
     std::shared_ptr<Session> GetSharedPtrFromThis();

--- a/test/download_tests.cpp
+++ b/test/download_tests.cpp
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include "cpr/accept_encoding.h"
 #include "cpr/cpr.h"
 
 #include "cpr/api.h"
@@ -18,10 +19,21 @@ bool write_data(std::string /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 
-TEST(DownloadTests, DownloadGzip) {
+TEST(DownloadTests, DownloadHeaderGzip) {
     cpr::Url url{server->GetBaseUrl() + "/download_gzip.html"};
     cpr::Session session;
     session.SetHeader(cpr::Header{{"Accept-Encoding", "gzip"}});
+    session.SetUrl(url);
+    cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(cpr::ErrorCode::OK, response.error.code);
+}
+
+TEST(DownloadTests, DownloadAcceptEncodingGzip) {
+    cpr::Url url{server->GetBaseUrl() + "/download_gzip.html"};
+    cpr::Session session;
+    session.SetAcceptEncoding(cpr::AcceptEncoding{cpr::AcceptEncodingMethods::gzip});
     session.SetUrl(url);
     cpr::Response response = session.Download(cpr::WriteCallback{write_data, 0});
     EXPECT_EQ(url, response.url);


### PR DESCRIPTION
Fixes #1008.

The following was not possible:
```c++
cpr::Session session;
session.SetAcceptEncoding(cpr::AcceptEncoding{cpr::AcceptEncodingMethods::gzip});
session.SetUrl("https://example.com");
cpr::Response response = session.Download(of);
```

Besides that, this PR fixes even more things that were not possible with `cpr::Download` like, proxy and TLS settings.