### PR TITLE
Optimization cookie time

### DIFF
--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -12,6 +12,7 @@
 #include <ios>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #if defined(_Win32)
@@ -53,7 +54,7 @@ Cookies parseCookies(curl_slist* raw_cookies) {
         while (tokens.size() < CURL_HTTP_COOKIE_SIZE) {
             tokens.emplace_back("");
         }
-        const std::time_t expires = static_cast<time_t>(std::stoul(tokens.at(static_cast<size_t>(CurlHTTPCookieField::Expires))));
+        const std::time_t expires = sTimestampToT(tokens.at(static_cast<size_t>(CurlHTTPCookieField::Expires)));
         cookies.emplace_back(Cookie{
                 tokens.at(static_cast<size_t>(CurlHTTPCookieField::Name)),
                 tokens.at(static_cast<size_t>(CurlHTTPCookieField::Value)),
@@ -235,6 +236,25 @@ bool isTrue(const std::string& s) {
     std::string temp_string{s};
     std::transform(temp_string.begin(), temp_string.end(), temp_string.begin(), [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); });
     return temp_string == "true";
+}
+
+time_t sTimestampToT(const std::string& st) {
+    // NOLINTNEXTLINE(google-runtime-int)
+    if (std::is_same_v<time_t, unsigned long>) {
+        return static_cast<time_t>(std::stoul(st));
+    }
+    // NOLINTNEXTLINE(google-runtime-int)
+    if (std::is_same_v<time_t, unsigned long long>) {
+        return static_cast<time_t>(std::stoull(st));
+    }
+    if (std::is_same_v<time_t, int>) {
+        return static_cast<time_t>(std::stoi(st));
+    }
+    // NOLINTNEXTLINE(google-runtime-int)
+    if (std::is_same_v<time_t, long>) {
+        return static_cast<time_t>(std::stol(st));
+    }
+    return static_cast<time_t>(std::stoll(st));
 }
 
 } // namespace cpr::util

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -42,6 +42,12 @@ std::string urlDecode(const std::string& s);
 void secureStringClear(std::string& s);
 bool isTrue(const std::string& s);
 
+/**
+ * Parses the given std::string into time_t (unix ms).
+ * This parsing happens time_t size agnostic since time_t does not use the same underlying type on all systems/compilers.
+ **/
+time_t sTimestampToT(const std::string&);
+
 } // namespace cpr::util
 
 #endif


### PR DESCRIPTION
In some environments (such as Win11 Visual Studio 2022), the long type is 32 bit, while the time_t type is 64 bit.

So in util.cpp>parseCookies()>`const std::time_t expires = static_cast<time_t>(std::stoul(tokens.at(static_cast<size_t>(CurlHTTPCookieField::Expires))));`, there may be an "stoul argument out of range" issue. Because `Cookie.ExpiresString` may be 64 bit, while the parameter for `std::stoul()` may be 32 bit.(From the source code of curl, it can be seen that the type of `Cookie.ExpiresString` is `time_t`)

So I added function `sTimestampToT()` to parse `Cookie.ExpiresString` based on different types of `time_t`.

What do everyone think? Welcome to correct.

Wishing everyone a happy life.