### PR TITLE
Use std::call_once instead of double-checked locking in singletons

### DIFF
--- a/include/cpr/singleton.h
+++ b/include/cpr/singleton.h
@@ -1,6 +1,7 @@
 #ifndef CPR_SINGLETON_H
 #define CPR_SINGLETON_H
 
+#include <cassert>
 #include <mutex>
 
 #ifndef CPR_DISABLE_COPY
@@ -10,38 +11,33 @@
 #endif
 
 #ifndef CPR_SINGLETON_DECL
-#define CPR_SINGLETON_DECL(Class) \
-  public:                         \
-    static Class* GetInstance();  \
-    static void ExitInstance();   \
-                                  \
-  private:                        \
-    CPR_DISABLE_COPY(Class)       \
-    static Class* s_pInstance;    \
-    static std::mutex s_mutex;
+#define CPR_SINGLETON_DECL(Class)    \
+  public:                            \
+    static Class* GetInstance();     \
+    static void ExitInstance();      \
+                                     \
+  private:                           \
+    CPR_DISABLE_COPY(Class)          \
+    static Class* s_pInstance;       \
+    static std::once_flag s_getFlag; \
+    static std::once_flag s_exitFlag;
 #endif
 
 #ifndef CPR_SINGLETON_IMPL
-#define CPR_SINGLETON_IMPL(Class)         \
-    Class* Class::s_pInstance = nullptr;  \
-    std::mutex Class::s_mutex;            \
-    Class* Class::GetInstance() {         \
-        if (s_pInstance == nullptr) {     \
-            s_mutex.lock();               \
-            if (s_pInstance == nullptr) { \
-                s_pInstance = new Class;  \
-            }                             \
-            s_mutex.unlock();             \
-        }                                 \
-        return s_pInstance;               \
-    }                                     \
-    void Class::ExitInstance() {          \
-        s_mutex.lock();                   \
-        if (s_pInstance) {                \
-            delete s_pInstance;           \
-            s_pInstance = nullptr;        \
-        }                                 \
-        s_mutex.unlock();                 \
+#define CPR_SINGLETON_IMPL(Class)                                            \
+    Class* Class::s_pInstance = nullptr;                                     \
+    std::once_flag Class::s_getFlag{};                                       \
+    std::once_flag Class::s_exitFlag{};                                      \
+    Class* Class::GetInstance() {                                            \
+        std::call_once(Class::s_getFlag, []() { s_pInstance = new Class; }); \
+        return s_pInstance;                                                  \
+    }                                                                        \
+    void Class::ExitInstance() {                                             \
+        std::call_once(Class::s_exitFlag, []() {                             \
+            assert(s_pInstance != 0);                                        \
+            delete s_pInstance;                                              \
+            s_pInstance = nullptr;                                           \
+        });                                                                  \
     }
 #endif
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,7 @@ add_cpr_test(interceptor_multi)
 add_cpr_test(multiperform)
 add_cpr_test(resolve)
 add_cpr_test(multiasync)
+add_cpr_test(singleton)
 
 if (ENABLE_SSL_TESTS)
     add_cpr_test(ssl)

--- a/test/singleton_tests.cpp
+++ b/test/singleton_tests.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+
+#include "singleton_tests.hpp"
+
+// NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
+CPR_SINGLETON_IMPL(TestSingleton)
+
+TEST(SingletonTests, GetInstanceTest) {
+    const TestSingleton* singleton = TestSingleton::GetInstance();
+    EXPECT_NE(singleton, nullptr);
+}
+
+TEST(SingletonTests, ExitInstanceTest) {
+    TestSingleton* singleton = TestSingleton::GetInstance();
+    TestSingleton::ExitInstance();
+    singleton = TestSingleton::GetInstance();
+    EXPECT_EQ(singleton, nullptr);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/singleton_tests.hpp
+++ b/test/singleton_tests.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "cpr/cpr.h"
+
+class TestSingleton {
+    CPR_SINGLETON_DECL(TestSingleton)
+  private:
+    TestSingleton() = default;
+};


### PR DESCRIPTION
Fixes #1041

- I used `std::call_once` to initialize and destroy singleton classes.
- I added basic tests for singleton class initialization and shutdown functions.

## Notes

I added an assertion to the `ExitInstance()` function to help users detect if they call it multiple times in the same program by accident. Correct me if I am mistaken, but I assumed singleton classes do not need to be initialized and shutdown more than once. The previous version of the code allowed for multiple cycles of initialization and shutdown.

## Other

The CONTRIBUTING.md file mentions `format-check.sh` that I don't see in the repository, and it also links to a different location for the repository, `https://github.com/whoshuu/cpr`.