### PR TITLE
fix: fallback from curl_multi_poll to curl_multi_wait before curl 7.66

### DIFF
--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <curl/curl.h>
 #include <curl/multi.h>
+#include <curl/curlver.h>
 #include <functional>
 #include <iosfwd>
 #include <iostream>
@@ -110,9 +111,16 @@ void MultiPerform::DoMultiPerform() {
 
         if (still_running) {
             const int timeout_ms{250};
+#if LIBCURL_VERSION_NUM >= 0x074200 // 7.66.0
             error_code = curl_multi_poll(multicurl_->handle, nullptr, 0, timeout_ms, nullptr);
             if (error_code) {
                 std::cerr << "curl_multi_poll() failed, code " << static_cast<int>(error_code) << '\n';
+#else
+            error_code = curl_multi_wait(multicurl_->handle, nullptr, 0, timeout_ms, nullptr);
+            if (error_code) {
+                std::cerr << "curl_multi_wait() failed, code " << static_cast<int>(error_code) << '\n';
+
+#endif
                 break;
             }
         }


### PR DESCRIPTION
According to [this article](https://curl.se/mail/lib-2019-07/0069.html), curl_multi_poll is a "drop-in function replacement" to curl_multi_wait that "waits more", and was introduced in [7.66](https://curl.se/mail/archive-2019-09/0002.html).

Replace call to curl_multi_poll by curl_multi_wait when curl version is less that 7.66.