### PR TITLE
parseHeader optimization: no intermediate std::vector

### DIFF
--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -71,16 +71,9 @@ Cookies parseCookies(curl_slist* raw_cookies) {
 
 Header parseHeader(const std::string& headers, std::string* status_line, std::string* reason) {
     Header header;
-    std::vector<std::string> lines;
     std::istringstream stream(headers);
-    {
-        std::string line;
-        while (std::getline(stream, line, '\n')) {
-            lines.push_back(line);
-        }
-    }
-
-    for (std::string& line : lines) {
+    std::string line;
+    while (std::getline(stream, line, '\n')) {
         if (line.substr(0, 5) == "HTTP/") {
             // set the status_line if it was given
             if ((status_line != nullptr) || (reason != nullptr)) {


### PR DESCRIPTION
The header is parsed line by line. However, it's not necessary to store the lines in an intermediate std::vector before doing the parsing. As by doing so, we used 2 heap allocations per header line, which are optimized away by this PR.

Test example:

```
#include <memory>
#include <string>

#include "cpr/cpr.h"
#include "cpr/cprtypes.h"
#include "cpr/redirect.h"
#include "cpr/session.h"
#include "httpServer.hpp"

using namespace cpr;

int main() {
    HttpServer server;
    server.SetUp();
    std::cout << server.GetBaseUrl() << std::endl;
    Url url{server.GetBaseUrl() + "/hello.html"};
    Response response = cpr::Get(url);
    std::cout << response.header["content-type"];
    server.TearDown();
    return 0;
}
```

Before, measured with `valgrind ./main`:

```
==207737==   total heap usage: 138 allocs, 138 frees, 115,676 bytes allocated
```

With this PR:

```
==251897==   total heap usage: 132 allocs, 132 frees, 115,390 bytes allocated

```