### PR TITLE
Fix sensitive data leaking in Authentication

### DIFF
--- a/cpr/auth.cpp
+++ b/cpr/auth.cpp
@@ -2,7 +2,6 @@
 #include "cpr/util.h"
 
 #include <string_view>
-#include <utility>
 
 namespace cpr {
 
@@ -11,18 +10,6 @@ Authentication::Authentication(std::string_view username, std::string_view passw
     auth_string_ += username;
     auth_string_ += ':';
     auth_string_ += password;
-}
-
-Authentication::Authentication(Authentication&& old) noexcept : auth_string_{std::move(old.auth_string_)}, auth_mode_{old.auth_mode_} {
-    old.auth_string_.resize(old.auth_string_.capacity());
-}
-
-Authentication& Authentication::operator=(Authentication&& old) noexcept {
-    auth_mode_ = old.auth_mode_;
-    util::secureStringClear(auth_string_);
-    auth_string_ = std::move(old.auth_string_);
-    old.auth_string_.resize(old.auth_string_.capacity());
-    return *this;
 }
 
 Authentication::~Authentication() noexcept {

--- a/cpr/auth.cpp
+++ b/cpr/auth.cpp
@@ -1,7 +1,30 @@
 #include "cpr/auth.h"
 #include "cpr/util.h"
 
+#include <string_view>
+#include <utility>
+
 namespace cpr {
+
+Authentication::Authentication(std::string_view username, std::string_view password, AuthMode auth_mode) : auth_mode_{auth_mode} {
+    auth_string_.reserve(username.size() + 1 + password.size());
+    auth_string_ += username;
+    auth_string_ += ':';
+    auth_string_ += password;
+}
+
+Authentication::Authentication(Authentication&& old) noexcept : auth_string_{std::move(old.auth_string_)}, auth_mode_{old.auth_mode_} {
+    old.auth_string_.resize(old.auth_string_.capacity());
+}
+
+Authentication& Authentication::operator=(Authentication&& old) noexcept {
+    auth_mode_ = old.auth_mode_;
+    util::secureStringClear(auth_string_);
+    auth_string_ = std::move(old.auth_string_);
+    old.auth_string_.resize(old.auth_string_.capacity());
+    return *this;
+}
+
 Authentication::~Authentication() noexcept {
     util::secureStringClear(auth_string_);
 }

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -2,8 +2,7 @@
 #define CPR_AUTH_H
 
 #include <string>
-
-#include <utility>
+#include <string_view>
 
 namespace cpr {
 
@@ -11,12 +10,12 @@ enum class AuthMode { BASIC, DIGEST, NTLM };
 
 class Authentication {
   public:
-    Authentication(std::string username, std::string password, AuthMode auth_mode) : auth_string_{std::move(username) + ":" + std::move(password)}, auth_mode_{std::move(auth_mode)} {}
+    Authentication(std::string_view username, std::string_view password, AuthMode auth_mode);
     Authentication(const Authentication& other) = default;
-    Authentication(Authentication&& old) noexcept = default;
+    Authentication(Authentication&& old) noexcept;
     ~Authentication() noexcept;
 
-    Authentication& operator=(Authentication&& old) noexcept = default;
+    Authentication& operator=(Authentication&& old) noexcept;
     Authentication& operator=(const Authentication& other) = default;
 
     const char* GetAuthString() const noexcept;

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -12,10 +12,8 @@ class Authentication {
   public:
     Authentication(std::string_view username, std::string_view password, AuthMode auth_mode);
     Authentication(const Authentication& other) = default;
-    Authentication(Authentication&& old) noexcept;
     ~Authentication() noexcept;
 
-    Authentication& operator=(Authentication&& old) noexcept;
     Authentication& operator=(const Authentication& other) = default;
 
     const char* GetAuthString() const noexcept;


### PR DESCRIPTION
The current Authentication constructor has multiple points where a copy can get made: in the arguments themselves, in the intermediate concatenations, and in the potential need for the concatenation to copy itself during a memory reallocation.

An additional copy of the auth data could end up unwiped in the implicit move constructor/assignment (in particular when small string optimization applies to the value).

Any such copies end up potentially leaving the sensitive data behind in memory, undermining the changes in #776 that were trying to securely erase such sensitive data.

This commit avoids any such copies by:
- changing Authentication to take std::string_views (instead of std::string) for username and password so that no copy of input will be done
- properly reserving auth_string_ to its required size before building it
- Adding an explicit move constructor that resizes the moved-from auth string to capacity to ensure it gets erased when SSO applies.
- Adding an explicit move assignment operator that wipes the current value before replacing it, and properly resizes the moved-from string to capacity to ensure it gets wiped when SSO applies.