### PR TITLE
Const Response::GetCertInfos()

### DIFF
--- a/cpr/response.cpp
+++ b/cpr/response.cpp
@@ -37,7 +37,7 @@ Response::Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text, std::
     curl_easy_getinfo(curl_->handle, CURLINFO_REDIRECT_COUNT, &redirect_count);
 }
 
-std::vector<CertInfo> Response::GetCertInfos() {
+std::vector<CertInfo> Response::GetCertInfos() const {
     assert(curl_);
     assert(curl_->handle);
     curl_certinfo* ci{nullptr};

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -45,7 +45,7 @@ class Response {
 
     Response() = default;
     Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text, std::string&& p_header_string, Cookies&& p_cookies, Error&& p_error);
-    std::vector<CertInfo> GetCertInfos();
+    [[nodiscard]] std::vector<CertInfo> GetCertInfos() const;
     Response(const Response& other) = default;
     Response(Response&& old) noexcept = default;
     ~Response() noexcept = default;


### PR DESCRIPTION
## Changes
* Makes `Response::GetCertInfos()` const

Fixes #1073.