### PR TITLE
add support for CURLAUTH_NEGOTIATE

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -386,6 +386,10 @@ void Session::SetAuth(const Authentication& auth) {
             curl_easy_setopt(curl_->handle, CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
             curl_easy_setopt(curl_->handle, CURLOPT_USERPWD, auth.GetAuthString());
             break;
+        case AuthMode::NEGOTIATE:
+            curl_easy_setopt(curl_->handle, CURLOPT_HTTPAUTH, CURLAUTH_NEGOTIATE);
+            curl_easy_setopt(curl_->handle, CURLOPT_USERPWD, auth.GetAuthString());
+            break;
     }
 }
 

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -7,7 +7,7 @@
 
 namespace cpr {
 
-enum class AuthMode { BASIC, DIGEST, NTLM };
+enum class AuthMode { BASIC, DIGEST, NTLM, NEGOTIATE };
 
 class Authentication {
   public:


### PR DESCRIPTION
Added login with CURLAUTH_NEGOTIATE so Windows kerberos authentication will be possible.
Tested under Windows 10 with libcurl 8.8.0