### PR TITLE
The header and write callback now uses a std::string_view as argument for data to avoid copying

### DIFF
--- a/include/cpr/callback.h
+++ b/include/cpr/callback.h
@@ -29,26 +29,26 @@ class HeaderCallback {
   public:
     HeaderCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    HeaderCallback(std::function<bool(std::string header, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
-    bool operator()(std::string header) const {
-        return callback(std::move(header), userdata);
+    HeaderCallback(std::function<bool(const std::string_view& header, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    bool operator()(const std::string_view& header) const {
+        return callback(header, userdata);
     }
 
     intptr_t userdata{};
-    std::function<bool(std::string header, intptr_t userdata)> callback;
+    std::function<bool(const std::string_view& header, intptr_t userdata)> callback;
 };
 
 class WriteCallback {
   public:
     WriteCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    WriteCallback(std::function<bool(std::string data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
-    bool operator()(std::string data) const {
-        return callback(std::move(data), userdata);
+    WriteCallback(std::function<bool(const std::string_view& data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    bool operator()(const std::string_view& data) const {
+        return callback(data, userdata);
     }
 
     intptr_t userdata{};
-    std::function<bool(std::string data, intptr_t userdata)> callback;
+    std::function<bool(const std::string_view& data, intptr_t userdata)> callback;
 };
 
 class ProgressCallback {

--- a/test/async_tests.cpp
+++ b/test/async_tests.cpp
@@ -14,7 +14,7 @@ using namespace cpr;
 
 static HttpServer* server = new HttpServer();
 
-bool write_data(std::string /*data*/, intptr_t /*userdata*/) {
+bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 

--- a/test/callback_tests.cpp
+++ b/test/callback_tests.cpp
@@ -857,7 +857,7 @@ TEST(CallbackDataTests, CallbackReadFunctionChunkedTest) {
 
 TEST(CallbackDataTests, CallbackHeaderFunctionCancelTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
-    Response response = Post(url, HeaderCallback{[](std::string /*header*/, intptr_t /*userdata*/) -> bool { return false; }});
+    Response response = Post(url, HeaderCallback{[](const std::string_view& /*header*/, intptr_t /*userdata*/) -> bool { return false; }});
     EXPECT_EQ(response.error.code, ErrorCode::REQUEST_CANCELLED);
 }
 
@@ -865,8 +865,8 @@ TEST(CallbackDataTests, CallbackHeaderFunctionTextTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
     std::vector<std::string> expected_headers{"HTTP/1.1 201 Created\r\n", "Content-Type: application/json\r\n", "\r\n"};
     std::set<std::string> response_headers;
-    Post(url, HeaderCallback{[&response_headers](const std::string& header, intptr_t /*userdata*/) -> bool {
-             response_headers.insert(header);
+    Post(url, HeaderCallback{[&response_headers](const std::string_view& header, intptr_t /*userdata*/) -> bool {
+             response_headers.insert(std::string{header});
              return true;
          }});
     for (std::string& header : expected_headers) {
@@ -877,7 +877,7 @@ TEST(CallbackDataTests, CallbackHeaderFunctionTextTest) {
 
 TEST(CallbackDataTests, CallbackWriteFunctionCancelTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
-    Response response = Post(url, WriteCallback{[](std::string /*header*/, intptr_t /*userdata*/) -> bool { return false; }});
+    Response response = Post(url, WriteCallback{[](const std::string_view& /*header*/, intptr_t /*userdata*/) -> bool { return false; }});
     EXPECT_EQ(response.error.code, ErrorCode::REQUEST_CANCELLED);
 }
 
@@ -888,7 +888,7 @@ TEST(CallbackDataTests, CallbackWriteFunctionTextTest) {
             "  \"x\": 5\n"
             "}"};
     std::string response_text;
-    Post(url, Payload{{"x", "5"}}, WriteCallback{[&response_text](const std::string& header, intptr_t /*userdata*/) -> bool {
+    Post(url, Payload{{"x", "5"}}, WriteCallback{[&response_text](const std::string_view& header, intptr_t /*userdata*/) -> bool {
              response_text.append(header);
              return true;
          }});

--- a/test/download_tests.cpp
+++ b/test/download_tests.cpp
@@ -15,7 +15,7 @@
 
 static cpr::HttpServer* server = new cpr::HttpServer();
 
-bool write_data(std::string /*data*/, intptr_t /*userdata*/) {
+bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 
@@ -123,7 +123,7 @@ TEST(DownloadTests, RangeTestMultipleRangesOption) {
     EXPECT_EQ(download_size, response.downloaded_bytes);
 }
 
-bool real_write_data(std::string data, intptr_t userdata) {
+bool real_write_data(const std::string_view& data, intptr_t userdata) {
     // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
     std::string* dst = reinterpret_cast<std::string*>(userdata);
     *dst += data;

--- a/test/interceptor_multi_tests.cpp
+++ b/test/interceptor_multi_tests.cpp
@@ -122,7 +122,7 @@ class ChangeRequestMethodToDeleteInterceptorMulti : public InterceptorMulti {
     }
 };
 
-bool write_data(std::string /*data*/, intptr_t /*userdata*/) {
+bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 

--- a/test/interceptor_tests.cpp
+++ b/test/interceptor_tests.cpp
@@ -94,7 +94,7 @@ class ChangeRequestMethodToDeleteInterceptor : public Interceptor {
     }
 };
 
-bool write_data(std::string /*data*/, intptr_t /*userdata*/) {
+bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 

--- a/test/multiperform_tests.cpp
+++ b/test/multiperform_tests.cpp
@@ -15,7 +15,7 @@ using namespace cpr;
 
 static HttpServer* server = new HttpServer();
 
-bool write_data(std::string /*data*/, intptr_t /*userdata*/) {
+bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -21,7 +21,7 @@ static HttpServer* server = new HttpServer();
 std::chrono::milliseconds sleep_time{50};
 std::chrono::seconds zero{0};
 
-bool write_data(std::string /*data*/, intptr_t /*userdata*/) {
+bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 


### PR DESCRIPTION
## Old

```c++
std::function<bool(std::string data, intptr_t userdata)> callback;
```

## New

```c++
std::function<bool(const std::string_view& data, intptr_t userdata)> callback;
```

With the new way we avoid copying the payload.