### PR TITLE
Handle multiple headers with the same name

### DIFF
--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -104,7 +104,11 @@ Header parseHeader(const std::string& headers, std::string* status_line, std::st
                 std::string value = line.substr(found + 1);
                 value.erase(0, value.find_first_not_of("\t "));
                 value.resize(std::min<size_t>(value.size(), value.find_last_not_of("\t\n\r ") + 1));
-                header[line.substr(0, found)] = value;
+                if (auto it = header.find(line.substr(0, found)); it != header.end()) {
+                    it->second = it->second + ", " + value;
+                } else {
+                    header[line.substr(0, found)] = value;
+                }
             }
         }
     }


### PR DESCRIPTION
According to the [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html), multiple headers with the same name can be found in an HTTP Request :
```
Example-Field: Foo, Bar
Example-Field: Baz

```

As the current implementation of parseHeader (util.cpp) uses a map, only the last value is kept. However, section 5.3 of linked RFC tells that we can just append the fields using comma SP as separator and keep the semantic. This is what I propose in this PR.