### PR TITLE
Ignore certificate revocation checks in case of missing or offline distribution points on Windows

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -206,6 +206,11 @@ void Session::prepareCommonShared() {
     curl_easy_setopt(curl_->handle, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
 #endif
 
+#if LIBCURL_VERSION_NUM >= 0x074600 // 7.70.0
+    // Ignore certificate revocation checks in case of missing or offline distribution points, on Windows:
+    curl_easy_setopt(curl_->handle, CURLOPT_SSL_OPTIONS, CURLSSLOPT_REVOKE_BEST_EFFORT);
+#endif
+
 // Ensure SSL no revoke is still set
 #if SUPPORT_SSL_NO_REVOKE
     if (noRevoke) {


### PR DESCRIPTION
Set the `CURLSSLOPT_REVOKE_BEST_EFFORT` option, if curl is on the version 7.70.0 or later.

The SSL option is equivalent to the `--ssl-revoke-best-effort` curl flag. This option results in ignoring errors regarding the revocation check being unable to take place. This is only an issue on Windows, due to this being the default behavior from schannel.

([source](https://lists.gnu.org/archive/html/gnunet-svn/2020-04/msg01007.html))