### PR TITLE
Fix 32bit Unittest Builds

### DIFF
--- a/cpr/threadpool.cpp
+++ b/cpr/threadpool.cpp
@@ -132,14 +132,15 @@ void ThreadPool::AddThread(std::thread* thread) {
     data.thread = std::shared_ptr<std::thread>(thread);
     data.id = thread->get_id();
     data.status = RUNNING;
-    data.start_time = time(nullptr);
-    data.stop_time = 0;
+    data.start_time = std::chrono::steady_clock::now();
+    data.stop_time = std::chrono::steady_clock::time_point::max();
     threads.emplace_back(data);
     thread_mutex.unlock();
 }
 
 void ThreadPool::DelThread(std::thread::id id) {
-    const time_t now = time(nullptr);
+    const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+
     thread_mutex.lock();
     --cur_thread_num;
     --idle_thread_num;
@@ -153,7 +154,7 @@ void ThreadPool::DelThread(std::thread::id id) {
             }
         } else if (iter->id == id) {
             iter->status = STOP;
-            iter->stop_time = time(nullptr);
+            iter->stop_time = std::chrono::steady_clock::now();
         }
         ++iter;
     }

--- a/include/cpr/threadpool.h
+++ b/include/cpr/threadpool.h
@@ -114,8 +114,8 @@ class ThreadPool {
         std::shared_ptr<std::thread> thread;
         std::thread::id id;
         Status status;
-        time_t start_time;
-        time_t stop_time;
+        std::chrono::steady_clock::time_point start_time;
+        std::chrono::steady_clock::time_point stop_time;
     };
 
     std::atomic<Status> status{Status::STOP};

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -113,8 +114,8 @@ TEST(CookiesTests, BasicCookiesTest) {
     cpr::Cookies res_cookies{response.cookies};
     std::string expected_text{"Basic Cookies"};
     cpr::Cookies expectedCookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
     };
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
@@ -138,8 +139,8 @@ TEST(CookiesTests, EmptyCookieTest) {
     cpr::Cookies res_cookies{response.cookies};
     std::string expected_text{"Empty Cookies"};
     cpr::Cookies expectedCookies{
-            {"SID", "", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
-            {"lang", "", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"SID", "", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"lang", "", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
     };
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
@@ -160,8 +161,8 @@ TEST(CookiesTests, EmptyCookieTest) {
 TEST(CookiesTests, ClientSetCookiesTest) {
     Url url{server->GetBaseUrl() + "/cookies_reflect.html"};
     Cookies cookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
     };
     Response response = cpr::Get(url, cookies);
     std::string expected_text{"SID=31d4d96e407aad42; lang=en-US;"};
@@ -175,8 +176,8 @@ TEST(CookiesTests, ClientSetCookiesTest) {
 TEST(CookiesTests, UnencodedCookiesTest) {
     Url url{server->GetBaseUrl() + "/cookies_reflect.html"};
     Cookies cookies{
-            {"SID", "31d4d  %$  96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"SID", "31d4d  %$  96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
     };
     cookies.encode = false;
     Response response = cpr::Get(url, cookies);

--- a/test/head_tests.cpp
+++ b/test/head_tests.cpp
@@ -54,8 +54,8 @@ TEST(HeadTests, CookieHeadTest) {
     Url url{server->GetBaseUrl() + "/basic_cookies.html"};
     Response response = cpr::Head(url);
     cpr::Cookies expectedCookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
     };
     cpr::Cookies res_cookies{response.cookies};
     EXPECT_EQ(std::string{}, response.text);

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -143,12 +143,10 @@ void HttpServer::OnRequestLowSpeedBytes(mg_connection* conn, mg_http_message* /*
 }
 
 void HttpServer::OnRequestBasicCookies(mg_connection* conn, mg_http_message* /*msg*/) {
-    time_t expires_time = 3905119080; // Expires=Wed, 30 Sep 2093 03:18:00 GMT
-    std::array<char, EXPIRES_STRING_SIZE> expires_string;
-    std::strftime(expires_string.data(), expires_string.size(), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&expires_time));
+    const std::string expires = "Wed, 30 Sep 2093 03:18:00 GMT";
 
-    std::string cookie1{"SID=31d4d96e407aad42; Expires=" + std::string(expires_string.data()) + "; Secure"};
-    std::string cookie2{"lang=en-US; Expires=" + std::string(expires_string.data()) + "; Secure"};
+    std::string cookie1{"SID=31d4d96e407aad42; Expires=" + expires + "; Secure"};
+    std::string cookie2{"lang=en-US; Expires=" + expires + "; Secure"};
     std::string headers =
             "Content-Type: text/html\r\n"
             "Set-Cookie: " +
@@ -162,12 +160,10 @@ void HttpServer::OnRequestBasicCookies(mg_connection* conn, mg_http_message* /*m
 }
 
 void HttpServer::OnRequestEmptyCookies(mg_connection* conn, mg_http_message* /*msg*/) {
-    time_t expires_time = 3905119080; // Expires=Wed, 30 Sep 2093 03:18:00 GMT
-    std::array<char, EXPIRES_STRING_SIZE> expires_string;
-    std::strftime(expires_string.data(), sizeof(expires_string), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&expires_time));
+    const std::string expires = "Wed, 30 Sep 2093 03:18:00 GMT";
 
-    std::string cookie1{"SID=; Expires=" + std::string(expires_string.data()) + "; Secure"};
-    std::string cookie2{"lang=; Expires=" + std::string(expires_string.data()) + "; Secure"};
+    std::string cookie1{"SID=; Expires=" + expires + "; Secure"};
+    std::string cookie2{"lang=; Expires=" + expires + "; Secure"};
     std::string headers =
             "Content-Type: text/html\r\n"
             "Set-Cookie: " +
@@ -181,7 +177,7 @@ void HttpServer::OnRequestEmptyCookies(mg_connection* conn, mg_http_message* /*m
 }
 
 void HttpServer::OnRequestCookiesReflect(mg_connection* conn, mg_http_message* msg) {
-    mg_str* request_cookies;
+    mg_str* request_cookies{nullptr};
     if ((request_cookies = mg_http_get_header(msg, "Cookie")) == nullptr) {
         std::string errorMessage{"Cookie not found"};
         SendError(conn, 400, errorMessage);
@@ -193,19 +189,17 @@ void HttpServer::OnRequestCookiesReflect(mg_connection* conn, mg_http_message* m
 }
 
 void HttpServer::OnRequestRedirectionWithChangingCookies(mg_connection* conn, mg_http_message* msg) {
-    time_t expires_time = 3905119080; // Expires=Wed, 30 Sep 2093 03:18:00 GMT
-    std::array<char, EXPIRES_STRING_SIZE> expires_string;
-    std::strftime(expires_string.data(), sizeof(expires_string), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&expires_time));
+    const std::string expires = "Wed, 30 Sep 2093 03:18:00 GMT";
 
-    mg_str* request_cookies;
+    mg_str* request_cookies{nullptr};
     std::string cookie_str;
     if ((request_cookies = mg_http_get_header(msg, "Cookie")) != nullptr) {
         cookie_str = std::string{request_cookies->ptr, request_cookies->len};
     }
 
     if (cookie_str.find("SID=31d4d96e407aad42") == std::string::npos) {
-        std::string cookie1{"SID=31d4d96e407aad42; Expires=" + std::string(expires_string.data()) + "; Secure"};
-        std::string cookie2{"lang=en-US; Expires=" + std::string(expires_string.data()) + "; Secure"};
+        std::string cookie1{"SID=31d4d96e407aad42; Expires=" + expires + "; Secure"};
+        std::string cookie2{"lang=en-US; Expires=" + expires + "; Secure"};
         std::string headers =
                 "Content-Type: text/html\r\n"
                 "Location: http://127.0.0.1:61936/redirection_with_changing_cookies.html\r\n"

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -1,3 +1,5 @@
+#include <chrono>
+#include <cstddef>
 #include <gtest/gtest.h>
 
 #include <array>
@@ -5,6 +7,7 @@
 #include <fstream>
 #include <string>
 
+#include "cpr/cookies.h"
 #include "cpr/cpr.h"
 #include "cpr/multipart.h"
 
@@ -630,10 +633,17 @@ TEST(UrlEncodedPostTests, PostWithNoBodyTest) {
 }
 
 static std::string getTimestamp() {
-    char buf[1000];
-    time_t now = time(0);
-    struct tm* tm = gmtime(&now);
-    strftime(buf, sizeof buf, "%a, %d %b %Y %H:%M:%S GMT", tm);
+    const std::chrono::system_clock::time_point tp = std::chrono::system_clock::now();
+    const time_t timeT = std::chrono::system_clock::to_time_t(tp);
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    struct tm* tm = gmtime(&timeT);
+
+    std::string buf;
+    buf.resize(EXPIRES_STRING_SIZE);
+
+    const size_t s = strftime(buf.data(), buf.size(), "%a, %d %b %Y %H:%M:%S GMT", tm);
+    EXPECT_GT(s, 0);
+    buf.resize(s);
     return buf;
 }
 

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -765,8 +765,8 @@ TEST(CookiesTests, BasicCookiesTest) {
     Cookies res_cookies{response.cookies};
     std::string expected_text{"Basic Cookies"};
     cpr::Cookies expectedCookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::from_time_t(3905119080)},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
     };
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(200, response.status_code);


### PR DESCRIPTION
Something like `time_t expires_time = 3905119080; // Expires=Wed, 30 Sep 2093 03:18:00 GMT` is not easily possible on older 32 bit systems. But this is what we are using in our unit tests.

A solution was to skip converting `time_t` to a string and providing the string directly.

## Changes
* Replaced `time_t` with `std::chrono` where ever possible. 