### PR TITLE
gcc 15

### DIFF
--- a/include/cpr/callback.h
+++ b/include/cpr/callback.h
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <functional>
+#include <cstdint>
 #include <optional>
 #include <utility>
 


### PR DESCRIPTION
intptr_t requires

#include <cstdint>

see

https://bugs.gentoo.org/937537