### PR TITLE
Curl 8.10.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,8 +271,8 @@ else()
         cmake_policy(SET CMP0135 NEW)
     endif()
     FetchContent_Declare(curl
-                         URL                    https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.xz
-                         URL_HASH               SHA256=6fea2aac6a4610fbd0400afb0bcddbe7258a64c63f1f68e5855ebc0c659710cd # the file hash for curl-8.7.1.tar.xz
+                         URL                    https://github.com/curl/curl/releases/download/curl-8_10_1/curl-8.10.1.tar.xz
+                         URL_HASH               SHA256=73a4b0e99596a09fa5924a4fb7e4b995a85fda0d18a2c02ab9cf134bebce04ee # the file hash for curl-8.10.1.tar.xz
                          USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
     FetchContent_MakeAvailable(curl)
 

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -14,6 +14,13 @@ using namespace cpr;
 
 static HttpServer* server = new HttpServer();
 
+TEST(BasicTests, XXXTest) {
+    Url url{"https://getsolara.dev/api/endpoint.json"};
+    Response response = cpr::Get(url);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 TEST(BasicTests, HelloWorldTest) {
     Url url{server->GetBaseUrl() + "/hello.html"};
     Response response = cpr::Get(url);

--- a/test/multiperform_tests.cpp
+++ b/test/multiperform_tests.cpp
@@ -92,10 +92,19 @@ TEST(MultiperformRemoveSessionTests, MultiperformRemoveMultipleSessionsTest) {
     }
 }
 
-TEST(MultiperformRemoveSessionTests, MultiperformRemoveNonExistingSessionTest) {
+TEST(MultiperformRemoveSessionTests, MultiperformRemoveNonExistingSessionEmptyTest) {
     std::shared_ptr<Session> session = std::make_shared<Session>();
     MultiPerform multiperform;
     EXPECT_THROW(multiperform.RemoveSession(session), std::invalid_argument);
+}
+
+TEST(MultiperformRemoveSessionTests, MultiperformRemoveNonExistingSessionTest) {
+    MultiPerform multiperform;
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    multiperform.AddSession(session);
+
+    std::shared_ptr<Session> session2 = std::make_shared<Session>();
+    EXPECT_THROW(multiperform.RemoveSession(session2), std::invalid_argument);
 }
 
 TEST(MultiperformGetTests, MultiperformSingleSessionGetTest) {


### PR DESCRIPTION
As described in #1100 on Windows curl changed the way certificate verification works. This lead to a bunch of certificates being rejected.

This has been fixed in curl 8.10.0 again and therefore we need to update.