### PR TITLE
Add generic request function in api.h

### DIFF
--- a/include/cpr/api.h
+++ b/include/cpr/api.h
@@ -23,6 +23,16 @@ namespace cpr {
 
 using AsyncResponse = AsyncWrapper<Response>;
 
+enum class HTTPMethod {
+    GET,
+    HEAD,
+    POST,
+    PUT,
+    DELETE,
+    OPTIONS,
+    PATCH,
+};
+
 namespace priv {
 
 template <bool processed_header, typename CurrentType>
@@ -384,6 +394,31 @@ std::vector<AsyncWrapper<Response, true>> MultiPutAsync(Ts&&... ts) {
     std::vector<AsyncWrapper<Response, true>> ret{};
     priv::setup_multiasync<&cpr::Session::Put>(ret, std::forward<Ts>(ts)...);
     return ret;
+}
+
+template <HTTPMethod method, typename... Ts>
+Response Request(Ts&&... ts) {
+    cpr::Session session;
+    cpr::priv::set_option(session, std::forward<Ts>(ts)...);
+
+    if constexpr (method == HTTPMethod::GET) {
+        return session.Get();
+    } else if constexpr (method == HTTPMethod::HEAD) {
+        return session.Head();
+    } else if constexpr (method == HTTPMethod::POST) {
+        return session.Post();
+    } else if constexpr (method == HTTPMethod::PUT) {
+        return session.Put();
+    } else if constexpr (method == HTTPMethod::DELETE) {
+        return session.Delete();
+    } else if constexpr (method == HTTPMethod::OPTIONS) {
+        return session.Options();
+    } else if constexpr (method == HTTPMethod::PATCH) {
+        return session.Patch();
+    } else {
+        // Must be template dependent until DR 2518 (C++23)
+        static_assert(method == HTTPMethod::GET, "Unknown method");
+    }
 }
 
 


### PR DESCRIPTION
Provides generic function to call any HTTP method.

This helps to avoid such code on your side:

```cpp
template<class ...Ts>
cpr::Response MakeRequest(std::string_view method, Ts&& ...ts) { // could be enum, string, or bool. Whatever what you use to select different HTTP method
    if (method == "GET") {
        return cpr::Get(std::forward<Ts>(ts)..., cpr::Header{{"Authorization", "token"}});
    else if (method == "POST") {
        return cpr::Post(std::forward<Ts>(ts)..., cpr::Header{{"Authorization", "token"}});
    } else {
        // and so on...
    }
}
```

Now you can do this:

```cpp
    template <cpr::HTTPMethod method, typename... Args>
    cpr::Response MakeRequest(Args&&... args) {
        return cpr::Request<method>(std::forward<Args>(args)..., cpr::Header{{"Authorization", "token"}});
    }
```

and call it like this:

```cpp
cpr::Response r = MakeRequest<cpr::HTTPMethod::kPost>(cpr::Url{"http://www.httpbin.org/post?a=b"}, cpr::Body{"{\"a\": true}"});
```

Ideas before the merge:
- Do we need tests for this function?
- This function can replace all existing functions like Post(), Get(), and other! Should I refactor it?
- HTTPMethod doesn't have Download since it's not a method. Do we need it?
- Do we need Async and/or Multi versions?

Resolves #1117