### PR TITLE
Curl Minimum Supported Version 7.64.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ if(CPR_USE_SYSTEM_CURL)
         find_package(CURL COMPONENTS HTTP HTTPS)
         if(CURL_FOUND)
             message(STATUS "Curl ${CURL_VERSION_STRING} found on this system.")
+
             # To be able to load certificates under Windows when using OpenSSL:
             if(CMAKE_USE_OPENSSL AND WIN32 AND (NOT (CURL_VERSION_STRING VERSION_GREATER_EQUAL "7.71.0")))
                 message(FATAL_ERROR "Your system curl version (${CURL_VERSION_STRING}) is too old to support OpenSSL on Windows which requires curl >= 7.71.0. Update your curl version, use WinSSL, disable SSL or use the built-in version of curl.")
@@ -202,6 +203,11 @@ if(CPR_USE_SYSTEM_CURL)
         else()
             message(FATAL_ERROR "Curl not found on this system. To use the built-in version set CPR_USE_SYSTEM_CURL to OFF.")
         endif()
+    endif()
+
+    # Check for the minimum supported curl version 
+    if(NOT (CURL_VERSION_STRING VERSION_GREATER_EQUAL "7.64.0"))
+        message(FATAL_ERROR "Your system curl version (${CURL_VERSION_STRING}) is too old! curl >= 7.64.0 is required. Update your curl version, or use the build in curl version e.g. via `cmake .. -DCPR_USE_SYSTEM_CURL=OFF` during CMake configure.")
     endif()
 else()
     message(STATUS "Configuring built-in curl...")
@@ -285,6 +291,15 @@ else()
     FetchContent_MakeAvailable(curl)
 
     restore_variable(DESTINATION CMAKE_CXX_CLANG_TIDY BACKUP CMAKE_CXX_CLANG_TIDY_BKP)
+endif()
+
+# Depending on which version of libcurl we are using the CMake target is called differently
+if(TARGET libcurl)
+    # Old curl CMake target name
+    set(CURL_LIB libcurl)
+else()
+    # New curl CMake target name
+    set(CURL_LIB CURL::libcurl)
 endif()
 
 # GTest configuration

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The only explicit requirements are:
 * a `C++17` compatible compiler such as Clang or GCC. The minimum required version of GCC is unknown, so if anyone has trouble building this library with a specific version of GCC, do let us know
 * in case you only have a `C++11` compatible compiler available, all versions below cpr 1.9.x are for you. The 1.10.0 release of cpr switches to `C++17` as a requirement.
 * If you would like to perform https requests `OpenSSL` and its development libraries are required.
+* If you do not use the build in version of [curl](https://github.com/curl/curl) but instead use your systems version, make sure you use a version `>= 7.64.0`. Lower versions are not supported. This means you need Debian `>= 10` or Ubuntu `>= 20.04 LTS`.
 
 ## Building cpr - Using vcpkg
 

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(cpr
 
 add_library(cpr::cpr ALIAS cpr)
 
-target_link_libraries(cpr PUBLIC CURL::libcurl) # todo should be private, but first dependencies in ssl_options need to be removed
+target_link_libraries(cpr PUBLIC ${CURL_LIB}) # todo should be private, but first dependencies in ssl_options need to be removed
 
 # Fix missing OpenSSL includes for Windows since in 'ssl_ctx.cpp' we include OpenSSL directly
 if(SSL_BACKEND_USED STREQUAL "OpenSSL")

--- a/cpr/error.cpp
+++ b/cpr/error.cpp
@@ -22,7 +22,12 @@ ErrorCode Error::getErrorCodeForCurlError(std::int32_t curl_code) {
             return ErrorCode::COULDNT_RESOLVE_HOST;
         case CURLE_COULDNT_CONNECT:
             return ErrorCode::COULDNT_CONNECT;
+// Name changed in curl >= 7.51.0.
+#if LIBCURL_VERSION_NUM >= 0x073300
         case CURLE_WEIRD_SERVER_REPLY:
+#else
+        case CURLE_FTP_WEIRD_SERVER_REPLY:
+#endif
             return ErrorCode::WEIRD_SERVER_REPLY;
         case CURLE_REMOTE_ACCESS_DENIED:
             return ErrorCode::REMOTE_ACCESS_DENIED;
@@ -66,8 +71,11 @@ ErrorCode Error::getErrorCodeForCurlError(std::int32_t curl_code) {
             return ErrorCode::TOO_MANY_REDIRECTS;
         case CURLE_UNKNOWN_OPTION:
             return ErrorCode::UNKNOWN_OPTION;
+// Added in curl 7.78.0.
+#if LIBCURL_VERSION_NUM >= 0x074E00
         case CURLE_SETOPT_OPTION_SYNTAX:
             return ErrorCode::SETOPT_OPTION_SYNTAX;
+#endif
         case CURLE_GOT_NOTHING:
             return ErrorCode::GOT_NOTHING;
         case CURLE_SSL_ENGINE_NOTFOUND:
@@ -94,44 +102,98 @@ ErrorCode Error::getErrorCodeForCurlError(std::int32_t curl_code) {
             return ErrorCode::SEND_FAIL_REWIND;
         case CURLE_SSL_ENGINE_INITFAILED:
             return ErrorCode::SSL_ENGINE_INITFAILED;
+// Added in curl 7.13.1.
+#if LIBCURL_VERSION_NUM >= 0x070D01
         case CURLE_LOGIN_DENIED:
             return ErrorCode::LOGIN_DENIED;
+#endif
+// Added in curl 7.16.0.
+#if LIBCURL_VERSION_NUM >= 0x071000
         case CURLE_SSL_CACERT_BADFILE:
             return ErrorCode::SSL_CACERT_BADFILE;
+#endif
+// Added in curl 7.16.1.
+#if LIBCURL_VERSION_NUM >= 0x071001
         case CURLE_SSL_SHUTDOWN_FAILED:
             return ErrorCode::SSL_SHUTDOWN_FAILED;
+#endif
+// Added in curl 7.18.2.
+#if LIBCURL_VERSION_NUM >= 0x071202
         case CURLE_AGAIN:
             return ErrorCode::AGAIN;
+#endif
+// Added in curl 7.19.0.
+#if LIBCURL_VERSION_NUM >= 0x071300
         case CURLE_SSL_CRL_BADFILE:
             return ErrorCode::SSL_CRL_BADFILE;
         case CURLE_SSL_ISSUER_ERROR:
             return ErrorCode::SSL_ISSUER_ERROR;
+#endif
+// Added in curl 7.21.0.
+#if LIBCURL_VERSION_NUM >= 0x071500
         case CURLE_CHUNK_FAILED:
             return ErrorCode::CHUNK_FAILED;
+#endif
+// Added in curl 7.30.0.
+#if LIBCURL_VERSION_NUM >= 0x071E00
         case CURLE_NO_CONNECTION_AVAILABLE:
             return ErrorCode::NO_CONNECTION_AVAILABLE;
+#endif
+// Added in curl 7.39.0.
+#if LIBCURL_VERSION_NUM >= 0x072700
         case CURLE_SSL_PINNEDPUBKEYNOTMATCH:
             return ErrorCode::SSL_PINNEDPUBKEYNOTMATCH;
+#endif
+// Added in curl 7.41.0.
+#if LIBCURL_VERSION_NUM >= 0x072900
         case CURLE_SSL_INVALIDCERTSTATUS:
             return ErrorCode::SSL_INVALIDCERTSTATUS;
+#endif
+// Added in curl 7.49.0.
+#if LIBCURL_VERSION_NUM >= 0x073100
         case CURLE_HTTP2_STREAM:
             return ErrorCode::HTTP2_STREAM;
+#endif
+// Added in curl 7.59.0.
+#if LIBCURL_VERSION_NUM >= 0x073B00
         case CURLE_RECURSIVE_API_CALL:
             return ErrorCode::RECURSIVE_API_CALL;
+#endif
+// Added in curl 7.66.0.
+#if LIBCURL_VERSION_NUM >= 0x074200
         case CURLE_AUTH_ERROR:
             return ErrorCode::AUTH_ERROR;
+#endif
+// Added in curl 7.68.0.
+#if LIBCURL_VERSION_NUM >= 0x074400
         case CURLE_HTTP3:
             return ErrorCode::HTTP3;
+#endif
+// Added in curl 7.69.0.
+#if LIBCURL_VERSION_NUM >= 0x074500
         case CURLE_QUIC_CONNECT_ERROR:
             return ErrorCode::QUIC_CONNECT_ERROR;
+#endif
+// Added in curl 7.73.0.
+#if LIBCURL_VERSION_NUM >= 0x074900
         case CURLE_PROXY:
             return ErrorCode::PROXY;
+#endif
+// Added in curl 7.77.0.
+#if LIBCURL_VERSION_NUM >= 0x074D00
         case CURLE_SSL_CLIENTCERT:
             return ErrorCode::SSL_CLIENTCERT;
+#endif
+// Added in curl 7.84.0.
+#if LIBCURL_VERSION_NUM >= 0x075400
         case CURLE_UNRECOVERABLE_POLL:
             return ErrorCode::UNRECOVERABLE_POLL;
+#endif
+// Added in curl 7.6.0.
+#if LIBCURL_VERSION_NUM >= 0x080600
         case CURLE_TOO_LARGE:
             return ErrorCode::TOO_LARGE;
+#endif
         default:
             return ErrorCode::UNKNOWN_ERROR;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ macro(add_cpr_test _TEST_NAME)
         test_server
         GTest::GTest
         cpr::cpr
-        CURL::libcurl)
+        ${CURL_LIB})
     add_test(NAME cpr_${_TEST_NAME}_tests COMMAND ${_TEST_NAME}_tests)
     # Group under the "tests" project folder in IDEs such as Visual Studio.
     set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")


### PR DESCRIPTION
### Changes
* Minimum supported libcurl version is `7.64.0` which corresponds to Debian 10 or Ubuntu 20.04 LTS. Everything bellow might, or might not work.
* Fixed `error.cpp` compilation with old libcurl versions.