### PR TITLE
`Refactored` timeout.h: added template ctr and removed redundant ctrs (#1129)

### DIFF
--- a/include/cpr/timeout.h
+++ b/include/cpr/timeout.h
@@ -8,12 +8,14 @@ namespace cpr {
 
 class Timeout {
   public:
+    // Template constructor to accept any chrono duration type and convert it to milliseconds
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Timeout(const std::chrono::milliseconds& duration) : ms{duration} {}
+    template <typename Rep, typename Period>
+    Timeout(const std::chrono::duration<Rep, Period>& duration)
+            : ms{std::chrono::duration_cast<std::chrono::milliseconds>(duration)} {}
+
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     Timeout(const std::int32_t& milliseconds) : Timeout{std::chrono::milliseconds(milliseconds)} {}
-    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Timeout(const std::chrono::seconds& duration) : ms{std::chrono::milliseconds(duration).count()} {}
 
     // No way around since curl uses a long here.
     // NOLINTNEXTLINE(google-runtime-int)


### PR DESCRIPTION
I have refactored the constructors of the `Timeout` class:
- Added template constructor that accepts any `std::chrono::duration` type and converts it to `std::chrono::milliseconds`
- Removed two redundant constructors for `milliseconds` and `seconds`
- Ctr for `int32_t` was untouched

I am not sure if we still want the `NOLINTNEXTLINE(...)` above the template ctr, but for consistency I have added it back.

- [x] I have made sure to run all test cases like described in the readme.

Fixes #1129.