### PR TITLE
Find the path to the certificate bundle in runtime

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -134,6 +135,31 @@ Session::Session() : curl_(new CurlHolder()) {
     curl_easy_setopt(curl_->handle, CURLOPT_NOPROGRESS, 1L);
     curl_easy_setopt(curl_->handle, CURLOPT_ERRORBUFFER, curl_->error.data());
     curl_easy_setopt(curl_->handle, CURLOPT_COOKIEFILE, "");
+
+#ifdef __linux__
+    // Make the binary portable even when curl was compiled on a different distribution
+    static const char* cert_path = nullptr;
+
+    // Find the system certificate store
+    if (cert_path == nullptr) {
+        // List of possible paths:
+        // https://github.com/curl/curl/blob/25d45e89d140d6ab27103cd7f8f6d7d6cf548d47/CMakeLists.txt#L919
+        static constexpr const char* certificatePaths[] = {"/etc/ssl/certs/ca-certificates.crt", "/etc/pki/tls/certs/ca-bundle.crt", "/usr/share/ssl/certs/ca-bundle.crt", "/usr/local/share/certs/ca-root-nss.crt", "/etc/ssl/cert.pem"};
+
+        for (const auto& path : certificatePaths) {
+            if (std::filesystem::exists(path)) {
+                cert_path = path;
+                break;
+            }
+        }
+    }
+
+    // Set certificate path
+    if (cert_path != nullptr) {
+        curl_easy_setopt(curl_->handle, CURLOPT_CAINFO, cert_path);
+    }
+#endif
+
 #ifdef CPR_CURL_NOSIGNAL
     curl_easy_setopt(curl_->handle, CURLOPT_NOSIGNAL, 1L);
 #endif


### PR DESCRIPTION
The change makes the compiled library work on
different distributions, even if the path to the
certificate bundle in runtime is different compared to the path where it was during compilation.

This can be useful when the compilation is done on a manylinux Docker image which is based on CentOS, but the compiled library/binaries are used on
Ubuntu or Debian.

Related issue: https://github.com/curl/curl/issues/11411

Maintainers of CURL were not interested in mainlining this, so I understand if this is not suitable for the default behavior, but it would be nice to be able to at least optionally turn that on in runtime.