### PR TITLE
Update To The Latest Clang-Tidy Version

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,7 +36,8 @@ Checks: '*,
 -readability-magic-numbers,
 -cppcoreguidelines-avoid-do-while,
 -llvmlibc-inline-function-decl,
--altera-struct-pack-align
+-altera-struct-pack-align,
+-boost-use-ranges
 '
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'src/*.hpp'

--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -34,7 +34,7 @@ const std::string Cookie::GetExpiresString() const {
 #ifdef _WIN32
     gmtime_s(&tm, &tt);
 #else
-    // NOLINTNEXTLINE(misc-include-cleaner) False positive since <ctime> is included
+    // NOLINTNEXTLINE(misc-include-cleaner,cert-err33-c) False positive since <ctime> is included. Also ignore the ret value here.
     gmtime_r(&tt, &tm);
 #endif
     ss << std::put_time(&tm, "%a, %d %b %Y %H:%M:%S GMT");

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -162,7 +162,7 @@ std::vector<Response> MultiPerform::ReadMultiInfo(const std::function<Response(S
     for (const std::pair<std::shared_ptr<Session>, HttpMethod>& pair : sessions_) {
         Session& current_session = *(pair.first);
         auto it = std::find_if(responses.begin(), responses.end(), [&current_session](const Response& response) { return current_session.curl_->handle == response.curl_->handle; });
-        const Response current_response = *it;
+        const Response current_response = *it; // NOLINT (performance-unnecessary-copy-initialization) False possible
         // Erase response from original vector to increase future search speed
         responses.erase(it);
         sorted_responses.push_back(current_response);

--- a/cpr/ssl_ctx.cpp
+++ b/cpr/ssl_ctx.cpp
@@ -54,6 +54,7 @@ using custom_unique_ptr = std::unique_ptr<T, deleter_from_fn<fn>>;
 using x509_ptr = custom_unique_ptr<X509, X509_free>;
 using bio_ptr = custom_unique_ptr<BIO, BIO_free>;
 
+namespace {
 inline std::string get_openssl_print_errors() {
     std::ostringstream oss;
     ERR_print_errors_cb(
@@ -65,6 +66,8 @@ inline std::string get_openssl_print_errors() {
             &oss);
     return oss.str();
 }
+
+} // namespace
 
 CURLcode sslctx_function_load_ca_cert_from_buffer(CURL* /*curl*/, void* sslctx, void* raw_cert_buf) {
     // Check arguments

--- a/cpr/threadpool.cpp
+++ b/cpr/threadpool.cpp
@@ -1,4 +1,5 @@
 #include "cpr/threadpool.h"
+#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <ctime>
@@ -20,12 +21,7 @@ int ThreadPool::Start(size_t start_threads) {
         return -1;
     }
     status = RUNNING;
-    if (start_threads < min_thread_num) {
-        start_threads = min_thread_num;
-    }
-    if (start_threads > max_thread_num) {
-        start_threads = max_thread_num;
-    }
+    start_threads = std::clamp(start_threads, min_thread_num, max_thread_num);
     for (size_t i = 0; i < start_threads; ++i) {
         CreateThread();
     }


### PR DESCRIPTION
* Ignoring clang-tidy warning `boost-use-ranges` since we are not using boost in this project.
* Switch to `std::clamp` instead of reimplementing it.
* Using anonymous namespaces