### PR TITLE
[BUG] Fix cpr::ssl:KeyBlob: Copy blob to curl

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -473,6 +473,7 @@ void Session::SetSslOptions(const SslOptions& options) {
         // NOLINTNEXTLINE (readability-container-data-pointer)
         blob.data = &key_blob[0];
         blob.len = key_blob.length();
+        blob.flags = CURL_BLOB_COPY;
         curl_easy_setopt(curl_->handle, CURLOPT_SSLKEY_BLOB, &blob);
         if (!options.key_type.empty()) {
             curl_easy_setopt(curl_->handle, CURLOPT_SSLKEYTYPE, options.key_type.c_str());


### PR DESCRIPTION
This fix addresses https://github.com/libcpr/cpr/issues/1150 
When passing a private key as blob as described in the docs (https://docs.libcpr.org/advanced-usage.html) the following error was returned for version 1.11.0:
_unable to set private key file: '(memory blob)' type PEM_
