### PR TITLE
Fix/vs19 nuget compatibility

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package-windows-latest:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - name: Set version based on input
       if: ${{ inputs.version }}
@@ -32,7 +32,7 @@ jobs:
       uses: nuget/setup-nuget@v1
     - name: "[Release_x86] Build & Install"
       env:
-        CMAKE_GENERATOR: "Visual Studio 17 2022"
+        CMAKE_GENERATOR: "Visual Studio 16 2019"
       uses: ashutoshvarma/action-cmake-build@master
       with:
         build-dir: ${{github.workspace}}/build
@@ -49,7 +49,7 @@ jobs:
       run: rm -r -fo ${{github.workspace}}/build
     - name: "[Debug_x86] Build & Install"
       env:
-        CMAKE_GENERATOR: "Visual Studio 17 2022"
+        CMAKE_GENERATOR: "Visual Studio 16 2019"
       uses: ashutoshvarma/action-cmake-build@master
       with:
         build-dir: ${{github.workspace}}/build
@@ -66,7 +66,7 @@ jobs:
       run: rm -r -fo ${{github.workspace}}/build
     - name: "[Release_x64] Build & Install"
       env:
-        CMAKE_GENERATOR: "Visual Studio 17 2022"
+        CMAKE_GENERATOR: "Visual Studio 16 2019"
       uses: ashutoshvarma/action-cmake-build@master
       with:
         build-dir: ${{github.workspace}}/build
@@ -83,7 +83,7 @@ jobs:
       run: rm -r -fo ${{github.workspace}}/build
     - name: "[Debug_x64] Build & Install"
       env:
-        CMAKE_GENERATOR: "Visual Studio 17 2022"
+        CMAKE_GENERATOR: "Visual Studio 16 2019"
       uses: ashutoshvarma/action-cmake-build@master
       with:
         build-dir: ${{github.workspace}}/build

--- a/nuget/libcpr.nuspec
+++ b/nuget/libcpr.nuspec
@@ -4,7 +4,7 @@
     <id>libcpr</id>
     <version>$VERSION$</version>
     <title>C++ Requests: Curl for People</title>
-    <authors>Simon Berger</authors>
+    <authors>Fabian Sauter</authors>
     <owners>Fabian Sauter, Kilian Traub, many other libcpr contributors</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>


### PR DESCRIPTION
Build the NuGet package with VS2019 in order to be able to use it in VS2019 and not just in VS2022.

Fixes #1146.