### PR TITLE
fix: let bad-host-tests pass when there is DNS error redirection

### DIFF
--- a/test/error_tests.cpp
+++ b/test/error_tests.cpp
@@ -76,7 +76,8 @@ TEST(ErrorTests, ProxyFailure) {
     Response response = cpr::Get(url, cpr::Proxies{{"http", "http://bad_host.libcpr.org"}});
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(0, response.status_code);
-    EXPECT_EQ(ErrorCode::COULDNT_RESOLVE_PROXY, response.error.code);
+    // Sometimes the DNS server returns a fake address instead of an NXDOMAIN response, leading to COULDNT_CONNECT.
+    EXPECT_TRUE(response.error.code == ErrorCode::COULDNT_RESOLVE_PROXY || response.error.code == ErrorCode::COULDNT_CONNECT);
 }
 
 TEST(ErrorTests, BoolFalseTest) {

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <cpr/error.h>
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -112,7 +113,8 @@ TEST(BasicTests, BadHostTest) {
     EXPECT_EQ(std::string{}, response.text);
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(0, response.status_code);
-    EXPECT_EQ(ErrorCode::COULDNT_RESOLVE_HOST, response.error.code);
+    // Sometimes the DNS server returns a fake address instead of an NXDOMAIN response, leading to COULDNT_CONNECT.
+    EXPECT_TRUE(response.error.code == ErrorCode::COULDNT_RESOLVE_HOST || response.error.code == ErrorCode::COULDNT_CONNECT);
 }
 
 TEST(CookiesTests, BasicCookiesTest) {

--- a/test/head_tests.cpp
+++ b/test/head_tests.cpp
@@ -47,7 +47,8 @@ TEST(HeadTests, BadHostHeadTest) {
     EXPECT_EQ(std::string{}, response.text);
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(0, response.status_code);
-    EXPECT_EQ(ErrorCode::COULDNT_RESOLVE_HOST, response.error.code);
+    // Sometimes the DNS server returns a fake address instead of an NXDOMAIN response, leading to COULDNT_CONNECT.
+    EXPECT_TRUE(response.error.code == ErrorCode::COULDNT_RESOLVE_HOST || response.error.code == ErrorCode::COULDNT_CONNECT);
 }
 
 TEST(HeadTests, CookieHeadTest) {

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -119,7 +119,8 @@ TEST(UrlEncodedPostTests, UrlPostBadHostTest) {
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{}, response.header["content-type"]);
     EXPECT_EQ(0, response.status_code);
-    EXPECT_EQ(ErrorCode::COULDNT_RESOLVE_HOST, response.error.code);
+    // Sometimes the DNS server returns a fake address instead of an NXDOMAIN response, leading to COULDNT_CONNECT.
+    EXPECT_TRUE(response.error.code == ErrorCode::COULDNT_RESOLVE_HOST || response.error.code == ErrorCode::COULDNT_CONNECT);
 }
 
 TEST(UrlEncodedPostTests, FormPostSingleTest) {

--- a/test/raw_body_tests.cpp
+++ b/test/raw_body_tests.cpp
@@ -110,7 +110,8 @@ TEST(BodyPostTests, UrlPostBadHostTest) {
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{}, response.header["content-type"]);
     EXPECT_EQ(0, response.status_code);
-    EXPECT_EQ(ErrorCode::COULDNT_RESOLVE_HOST, response.error.code);
+    // Sometimes the DNS server returns a fake address instead of an NXDOMAIN response, leading to COULDNT_CONNECT.
+    EXPECT_TRUE(response.error.code == ErrorCode::COULDNT_RESOLVE_HOST || response.error.code == ErrorCode::COULDNT_CONNECT);
 }
 
 TEST(BodyPostTests, StringMoveBodyTest) {


### PR DESCRIPTION
## Reason

In bad host tests, when the DNS server is configured with error redirection, it may return a fake IP such as `127.0.0.2` instead of an NXDOMAIN response, which causes the tests fail. #1165 

## Solution

Add a "OR" condition to those tests, both `CURLE_COULDNT_RESOLVE_HOST (6)` and `CURLE_COULDNT_CONNECT (7)` should pass.