### PR TITLE
Add enforced HTTP/3

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -618,6 +618,11 @@ void Session::SetHttpVersion(const HttpVersion& version) {
             curl_easy_setopt(curl_->handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3);
             break;
 #endif
+#if LIBCURL_VERSION_NUM >= 0x075701 // 7.87.1, but corresponds to 7.88.0 tag
+        case HttpVersionCode::VERSION_3_0_ONLY:
+            curl_easy_setopt(curl_->handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3ONLY);
+            break;
+#endif
 
         default: // Should not happen
             throw std::invalid_argument("Invalid/Unknown HTTP version type.");

--- a/include/cpr/http_version.h
+++ b/include/cpr/http_version.h
@@ -46,7 +46,14 @@ enum class HttpVersionCode {
      * Requires prior knowledge that the server supports HTTP 3.0 since there is no gracefully downgrade.
      * Fallback to HTTP 1.1 if negotiation fails.
      **/
-    VERSION_3_0
+    VERSION_3_0,
+#endif
+#if LIBCURL_VERSION_NUM >= 0x075701 // 7.87.1, but corresponds to 7.88.0 tag
+    /**
+     * Enforce HTTP 3.0 requests without fallback.
+     * Requires prior knowledge that the server supports HTTP 3.0 since there is no gracefully downgrade.
+     **/
+    VERSION_3_0_ONLY
 #endif
 };
 


### PR DESCRIPTION
I hit nullptr dereference, when I manually created MultiPerform, but I didn't add any Interceptors.