### PR TITLE
Fix Seg-fault when setting proxy username + password

### DIFF
--- a/cpr/curlholder.cpp
+++ b/cpr/curlholder.cpp
@@ -1,9 +1,9 @@
 #include "cpr/curlholder.h"
+#include "cpr/secure_string.h"
 #include <cassert>
 #include <curl/curl.h>
 #include <curl/easy.h>
 #include <string_view>
-#include "cpr/secure_string.h"
 
 namespace cpr {
 CurlHolder::CurlHolder() {

--- a/cpr/proxyauth.cpp
+++ b/cpr/proxyauth.cpp
@@ -1,6 +1,7 @@
 #include "cpr/proxyauth.h"
 #include <string>
 #include <string_view>
+#include "cpr/secure_string.h"
 
 namespace cpr {
 

--- a/cpr/proxyauth.cpp
+++ b/cpr/proxyauth.cpp
@@ -12,6 +12,14 @@ std::string_view EncodedAuthentication::GetPassword() const {
     return password;
 }
 
+const util::SecureString& EncodedAuthentication::GetUsernameUnderlying() const {
+    return username;
+}
+
+const util::SecureString& EncodedAuthentication::GetPasswordUnderlying() const {
+    return password;
+}
+
 bool ProxyAuthentication::has(const std::string& protocol) const {
     return proxyAuth_.count(protocol) > 0;
 }
@@ -22,6 +30,14 @@ std::string_view ProxyAuthentication::GetUsername(const std::string& protocol) {
 
 std::string_view ProxyAuthentication::GetPassword(const std::string& protocol) {
     return proxyAuth_[protocol].GetPassword();
+}
+
+const util::SecureString& ProxyAuthentication::GetUsernameUnderlying(const std::string& protocol) const {
+    return proxyAuth_.at(protocol).GetUsernameUnderlying();
+}
+
+const util::SecureString& ProxyAuthentication::GetPasswordUnderlying(const std::string& protocol) const {
+    return proxyAuth_.at(protocol).GetPasswordUnderlying();
 }
 
 } // namespace cpr

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -177,6 +177,15 @@ void Session::prepareCommonShared() {
     if (proxies_.has(protocol)) {
         curl_easy_setopt(curl_->handle, CURLOPT_PROXY, proxies_[protocol].c_str());
         if (proxyAuth_.has(protocol)) {
+            // this worked:
+            // std::string password = "password";
+            // curl_easy_setopt(curl_->handle, CURLOPT_PROXYPASSWORD, password.c_str());
+            // std::string_view usernameView = proxyAuth_.GetUsername(protocol);
+            //             std::string username = "user";
+            // std::string username(usernameView);
+            // curl_easy_setopt(curl_->handle, CURLOPT_PROXYUSERNAME, username.data());
+            // curl_easy_setopt(curl_->handle, CURLOPT_PROXYUSERNAME, usernameView.data());
+            //  this does trigger the segfault (original code):
             curl_easy_setopt(curl_->handle, CURLOPT_PROXYUSERNAME, proxyAuth_.GetUsername(protocol));
             curl_easy_setopt(curl_->handle, CURLOPT_PROXYPASSWORD, proxyAuth_.GetPassword(protocol));
         }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -177,17 +177,8 @@ void Session::prepareCommonShared() {
     if (proxies_.has(protocol)) {
         curl_easy_setopt(curl_->handle, CURLOPT_PROXY, proxies_[protocol].c_str());
         if (proxyAuth_.has(protocol)) {
-            // this worked:
-            // std::string password = "password";
-            // curl_easy_setopt(curl_->handle, CURLOPT_PROXYPASSWORD, password.c_str());
-            // std::string_view usernameView = proxyAuth_.GetUsername(protocol);
-            //             std::string username = "user";
-            // std::string username(usernameView);
-            // curl_easy_setopt(curl_->handle, CURLOPT_PROXYUSERNAME, username.data());
-            // curl_easy_setopt(curl_->handle, CURLOPT_PROXYUSERNAME, usernameView.data());
-            //  this does trigger the segfault (original code):
-            curl_easy_setopt(curl_->handle, CURLOPT_PROXYUSERNAME, proxyAuth_.GetUsername(protocol));
-            curl_easy_setopt(curl_->handle, CURLOPT_PROXYPASSWORD, proxyAuth_.GetPassword(protocol));
+            curl_easy_setopt(curl_->handle, CURLOPT_PROXYUSERNAME, proxyAuth_.GetUsername(protocol).data());
+            curl_easy_setopt(curl_->handle, CURLOPT_PROXYPASSWORD, proxyAuth_.GetPassword(protocol).data());
         }
     }
     // handle NO_PROXY override passed through Proxies object

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -177,8 +177,8 @@ void Session::prepareCommonShared() {
     if (proxies_.has(protocol)) {
         curl_easy_setopt(curl_->handle, CURLOPT_PROXY, proxies_[protocol].c_str());
         if (proxyAuth_.has(protocol)) {
-            curl_easy_setopt(curl_->handle, CURLOPT_PROXYUSERNAME, proxyAuth_.GetUsername(protocol).data());
-            curl_easy_setopt(curl_->handle, CURLOPT_PROXYPASSWORD, proxyAuth_.GetPassword(protocol).data());
+            curl_easy_setopt(curl_->handle, CURLOPT_PROXYUSERNAME, proxyAuth_.GetUsernameUnderlying(protocol).c_str());
+            curl_easy_setopt(curl_->handle, CURLOPT_PROXYPASSWORD, proxyAuth_.GetPasswordUnderlying(protocol).c_str());
         }
     }
     // handle NO_PROXY override passed through Proxies object

--- a/include/cpr/proxyauth.h
+++ b/include/cpr/proxyauth.h
@@ -27,6 +27,8 @@ class EncodedAuthentication {
 
     [[nodiscard]] std::string_view GetUsername() const;
     [[nodiscard]] std::string_view GetPassword() const;
+    [[nodiscard]] const util::SecureString& GetUsernameUnderlying() const;
+    [[nodiscard]] const util::SecureString& GetPasswordUnderlying() const;
 
   private:
     util::SecureString username;
@@ -42,6 +44,8 @@ class ProxyAuthentication {
     [[nodiscard]] bool has(const std::string& protocol) const;
     [[nodiscard]] std::string_view GetUsername(const std::string& protocol);
     [[nodiscard]] std::string_view GetPassword(const std::string& protocol);
+    [[nodiscard]] const util::SecureString& GetUsernameUnderlying(const std::string& protocol) const;
+    [[nodiscard]] const util::SecureString& GetPasswordUnderlying(const std::string& protocol) const;
 
   private:
     std::map<std::string, EncodedAuthentication> proxyAuth_;

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -296,6 +296,7 @@ class Session : public std::enable_shared_from_this<Session> {
      **/
     void prepareCommonDownload();
     void prepareHeader();
+    void prepareProxy();
     CURLcode DoEasyPerform();
     void prepareBodyPayloadOrMultipart() const;
     /**

--- a/test/proxy_auth_tests.cpp
+++ b/test/proxy_auth_tests.cpp
@@ -17,6 +17,16 @@ using namespace cpr;
 
 static HttpServer* server = new HttpServer();
 
+TEST(ProxyAuthTests, SetProxyCredentials) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    Session session;
+    session.SetUrl(url);
+    session.SetProxies(Proxies{{"http", HTTP_PROXY}, {"https", HTTPS_PROXY}});
+    session.SetProxyAuth({{"http", EncodedAuthentication{PROXY_USER, PROXY_PASS}}, {"https", EncodedAuthentication{PROXY_USER, PROXY_PASS}}});
+    session.PrepareGet();
+    EXPECT_TRUE(true);
+}
+
 // TODO: These should be fixed after a source code implementation of a proxy
 #if defined(false)
 TEST(ProxyAuthTests, SingleProxyTest) {


### PR DESCRIPTION
Providing a char* to underlying data of string_view instead string_view itself to curl api.
Fixes #1180 