### PR TITLE
Cookie expires date is now only 100 days in the future

### DIFF
--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -116,8 +116,8 @@ TEST(CookiesTests, BasicCookiesTest) {
     cpr::Cookies res_cookies{response.cookies};
     std::string expected_text{"Basic Cookies"};
     cpr::Cookies expectedCookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
     };
     EXPECT_EQ(expected_text, response.text);
     EXPECT_EQ(url, response.url);
@@ -141,8 +141,8 @@ TEST(CookiesTests, EmptyCookieTest) {
     cpr::Cookies res_cookies{response.cookies};
     std::string expected_text{"Empty Cookies"};
     cpr::Cookies expectedCookies{
-            {"SID", "", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
-            {"lang", "", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"SID", "", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
+            {"lang", "", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
     };
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
@@ -163,8 +163,8 @@ TEST(CookiesTests, EmptyCookieTest) {
 TEST(CookiesTests, ClientSetCookiesTest) {
     Url url{server->GetBaseUrl() + "/cookies_reflect.html"};
     Cookies cookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
     };
     Response response = cpr::Get(url, cookies);
     std::string expected_text{"SID=31d4d96e407aad42; lang=en-US;"};
@@ -178,8 +178,8 @@ TEST(CookiesTests, ClientSetCookiesTest) {
 TEST(CookiesTests, UnencodedCookiesTest) {
     Url url{server->GetBaseUrl() + "/cookies_reflect.html"};
     Cookies cookies{
-            {"SID", "31d4d  %$  96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"SID", "31d4d  %$  96e407aad42", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
     };
     cookies.encode = false;
     Response response = cpr::Get(url, cookies);

--- a/test/head_tests.cpp
+++ b/test/head_tests.cpp
@@ -55,8 +55,8 @@ TEST(HeadTests, CookieHeadTest) {
     Url url{server->GetBaseUrl() + "/basic_cookies.html"};
     Response response = cpr::Head(url);
     cpr::Cookies expectedCookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
     };
     cpr::Cookies res_cookies{response.cookies};
     EXPECT_EQ(std::string{}, response.text);

--- a/test/httpServer.hpp
+++ b/test/httpServer.hpp
@@ -1,11 +1,9 @@
 #ifndef CPR_TEST_HTTP_SERVER_H
 #define CPR_TEST_HTTP_SERVER_H
 
-#include <memory>
 #include <string>
 
 #include "abstractServer.hpp"
-#include "cpr/cpr.h"
 #include "mongoose.h"
 
 namespace cpr {
@@ -17,6 +15,17 @@ class HttpServer : public AbstractServer {
     uint16_t GetPort() override;
 
     void OnRequest(mg_connection* conn, mg_http_message* msg) override;
+
+    /**
+     * Returns the current date and time + 100 hours from when this function was invoked for the first time.
+     **/
+    static std::chrono::system_clock::time_point GetCookieExpiresIn100HoursTimePoint();
+
+    /**
+     * Returns the current date and time + 100 hours from when this function (or better GetCookieExpiresIn100HoursTimePoint()) was invoked for the first time as cookies expires string.
+     * For example: Wed, 30 Sep 2093 03:18:00 GMT
+     **/
+    static std::string GetCookieExpiresIn100HoursString();
 
   private:
     static void OnRequestHello(mg_connection* conn, mg_http_message* msg);

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -778,8 +778,8 @@ TEST(CookiesTests, BasicCookiesTest) {
     Cookies res_cookies{response.cookies};
     std::string expected_text{"Basic Cookies"};
     cpr::Cookies expectedCookies{
-            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
-            {"lang", "en-US", "127.0.0.1", false, "/", true, std::chrono::system_clock::time_point{} + std::chrono::seconds(3905119080)},
+            {"SID", "31d4d96e407aad42", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
+            {"lang", "en-US", "127.0.0.1", false, "/", true, HttpServer::GetCookieExpiresIn100HoursTimePoint()},
     };
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(200, response.status_code);


### PR DESCRIPTION
This fixes https://github.com/libcpr/cpr/issues/1183

Refactors the way cookie expires strings are generated and validated since with [curl 8.12.0](https://github.com/curl/curl/releases/tag/curl-8_12_0)  they introduced (https://github.com/curl/curl/pull/15937) parsing only cookies +400 days in the future.