### PR TITLE
Fixed memory leak in threadpool

### DIFF
--- a/include/cpr/threadpool.h
+++ b/include/cpr/threadpool.h
@@ -53,11 +53,11 @@ class ThreadPool {
         return idle_thread_num;
     }
 
-    bool IsStarted() {
+    bool IsStarted() const {
         return status != STOP;
     }
 
-    bool IsStopped() {
+    bool IsStopped() const {
         return status == STOP;
     }
 
@@ -65,7 +65,7 @@ class ThreadPool {
     int Stop();
     int Pause();
     int Resume();
-    int Wait();
+    int Wait() const;
 
     /**
      * Return a future, calling future.get() will wait task done and return RetType.
@@ -95,7 +95,7 @@ class ThreadPool {
 
   private:
     bool CreateThread();
-    void AddThread(std::thread* thread);
+    void AddThread(const std::shared_ptr<std::thread>& thread);
     void DelThread(std::thread::id id);
 
   public:


### PR DESCRIPTION
Transitioning from raw pointers (`std::thread*`) to `std::shared_ptr<std::thread>` to fix memory leak (there seems to be nothing that `delete` the raw ptr after the thread is terminated).

- `std::thread` objects now are wrapped in `std::shared_ptr` (so the memory is now automatically managed)
- `CreateThread` now creates thread using `std::make_shared`
- `AddThread` has been modified to accept `std::shared_ptr<std::thread>` instead of raw pointers