### PR TITLE
feat: Use CMAKE_MSVC_RUNTIME_LIBRARY for runtime selection in MSVC(#1…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,6 @@ if (MSVC)
         message(STATUS "Build windows dynamic libs.")
     else()
         # Add this to build windows pure static library.
-        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
         message(STATUS "Build windows static libs.")
     endif()
 endif()


### PR DESCRIPTION
feat: Use CMAKE_MSVC_RUNTIME_LIBRARY for runtime selection in MSVC(#1198)

Previously, when BUILD_SHARED_LIBS was set to FALSE (OFF), the runtime library was
forcibly set to MultiThreaded. This commit replaces that behavior by using the
CMAKE_MSVC_RUNTIME_LIBRARY option, allowing users to select between MultiThreaded
and MultiThreadedDLL as a build option.
