### PR TITLE
Update CMake fetch_content example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ include(FetchContent)
 FetchContent_Declare(cpr GIT_REPOSITORY https://github.com/libcpr/cpr.git
                          GIT_TAG dd967cb48ea6bcbad9f1da5ada0db8ac0d532c06) # Replace with your desired git commit from: https://github.com/libcpr/cpr/releases
 FetchContent_MakeAvailable(cpr)
+include_directories(${cpr_SOURCE_DIR}/include)
 ```
 
 This will produce the target `cpr::cpr` which you can link against the typical way:


### PR DESCRIPTION
`include_directories` is missing in the CMake fetch_content example, which may cause a compile error sometimes, like below:
```bash
/path/to/file.h:18:10: fatal error: cpr/cpr.h: No such file or directory
   18 | #include <cpr/cpr.h>
      |          ^~~~~~~~~~~
```

CMake fetch_content example in README:
```CMake
include(FetchContent)
FetchContent_Declare(cpr GIT_REPOSITORY https://github.com/libcpr/cpr.git
                         GIT_TAG dd967cb48ea6bcbad9f1da5ada0db8ac0d532c06) # Replace with your desired git commit from: https://github.com/libcpr/cpr/releases
FetchContent_MakeAvailable(cpr)
```




