### PR TITLE
Changed LowSpeed to use std::chrono

### DIFF
--- a/include/cpr/low_speed.h
+++ b/include/cpr/low_speed.h
@@ -2,15 +2,20 @@
 #define CPR_LOW_SPEED_H
 
 #include <cstdint>
+#include <chrono>
 
 namespace cpr {
 
 class LowSpeed {
   public:
-    LowSpeed(const std::int32_t p_limit, const std::int32_t p_time) : limit(p_limit), time(p_time) {}
+
+    [[deprecated("Will be removed in CPR 2.x - Use the constructor with std::chrono::seconds instead of std::int32_t")]]
+    LowSpeed(const std::int32_t p_limit, const std::int32_t p_time) : limit(p_limit), time(std::chrono::seconds(p_time)) {}
+
+    LowSpeed(const std::int32_t p_limit, const std::chrono::seconds p_time) : limit(p_limit), time(p_time) {}
 
     std::int32_t limit;
-    std::int32_t time;
+    std::chrono::seconds time;
 };
 
 } // namespace cpr

--- a/test/error_tests.cpp
+++ b/test/error_tests.cpp
@@ -59,14 +59,14 @@ TEST(ErrorTests, ChronoConnectTimeoutFailure) {
 
 TEST(ErrorTests, LowSpeedTimeFailure) {
     Url url{server->GetBaseUrl() + "/low_speed.html"};
-    Response response = cpr::Get(url, cpr::LowSpeed{1000, 1});
+    Response response = cpr::Get(url, cpr::LowSpeed{1000, std::chrono::seconds(1)});
     // Do not check for the HTTP status code, since libcurl always provides the status code of the header if it was received
     EXPECT_EQ(ErrorCode::OPERATION_TIMEDOUT, response.error.code);
 }
 
 TEST(ErrorTests, LowSpeedBytesFailure) {
     Url url{server->GetBaseUrl() + "/low_speed_bytes.html"};
-    Response response = cpr::Get(url, cpr::LowSpeed{1000, 1});
+    Response response = cpr::Get(url, cpr::LowSpeed{1000, std::chrono::seconds(1)});
     // Do not check for the HTTP status code, since libcurl always provides the status code of the header if it was received
     EXPECT_EQ(ErrorCode::OPERATION_TIMEDOUT, response.error.code);
 }

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -591,7 +591,7 @@ TEST(LowSpeedTests, SetLowSpeedTest) {
     Url url{server->GetBaseUrl() + "/hello.html"};
     Session session;
     session.SetUrl(url);
-    session.SetLowSpeed({1, 1});
+    session.SetLowSpeed({1, std::chrono::seconds(1)});
     Response response = session.Get();
     std::string expected_text{"Hello world!"};
     EXPECT_EQ(expected_text, response.text);


### PR DESCRIPTION
Use std::chrono::seconds instead of std::int32_t for time parameter in cpr::LowSpeed