### PR TITLE
CURL 8.13 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,8 +295,8 @@ else()
         cmake_policy(SET CMP0135 NEW)
     endif()
     FetchContent_Declare(curl
-                         URL                    https://github.com/curl/curl/releases/download/curl-8_10_1/curl-8.10.1.tar.xz
-                         URL_HASH               SHA256=73a4b0e99596a09fa5924a4fb7e4b995a85fda0d18a2c02ab9cf134bebce04ee # the file hash for curl-8.10.1.tar.xz
+                         URL                    https://github.com/curl/curl/releases/download/curl-8_13_0/curl-8.13.0.tar.xz
+                         URL_HASH               SHA256=4a093979a3c2d02de2fbc00549a32771007f2e78032c6faa5ecd2f7a9e152025 # the file hash for curl-8.13.0.tar.xz
                          USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
     FetchContent_MakeAvailable(curl)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,8 @@ if (ENABLE_SSL_TESTS)
     add_library(test_server STATIC
                 abstractServer.cpp
                 httpServer.cpp
-                httpsServer.cpp)
+                httpsServer.cpp
+                testUtils.cpp)
 else ()
     add_library(test_server STATIC
                 abstractServer.cpp
@@ -67,6 +68,7 @@ add_cpr_test(multiasync)
 add_cpr_test(file_upload)
 add_cpr_test(singleton)
 add_cpr_test(threadpool)
+add_cpr_test(testUtils)
 
 if (ENABLE_SSL_TESTS)
     add_cpr_test(ssl)

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -1181,6 +1181,7 @@ TEST(LocalPortTests, SetLocalPortTest) {
 
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
+    errno = 0;
     // NOLINTNEXTLINE(google-runtime-int)
     unsigned long port_from_response = std::strtoul(response.text.c_str(), nullptr, 10);
     EXPECT_EQ(errno, 0);
@@ -1216,6 +1217,7 @@ TEST(LocalPortTests, SetOptionTest) {
 
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
+    errno = 0;
     // NOLINTNEXTLINE(google-runtime-int)
     unsigned long port_from_response = std::strtoul(response.text.c_str(), nullptr, 10);
     EXPECT_EQ(errno, 0);

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -13,6 +13,7 @@
 
 #include "cpr/accept_encoding.h"
 #include "httpServer.hpp"
+#include "testUtils.hpp"
 
 using namespace cpr;
 using namespace std::chrono_literals;
@@ -1156,28 +1157,19 @@ TEST(CurlHolderManipulateTests, CustomOptionTest) {
 TEST(LocalPortTests, SetLocalPortTest) {
     Url url{server->GetBaseUrl() + "/local_port.html"};
     Session session;
-    uint16_t local_port{0};
-    uint16_t local_port_range{0};
     Response response;
-
-    // Try up to 10 times to get a free local port
-    for (size_t i = 0; i < 10; i++) {
-        session.SetUrl(url);
-        local_port = 40252 + (i * 100); // beware of HttpServer::GetPort when changing
-        local_port_range = 7000;
-        session.SetLocalPort(local_port);
-        session.SetLocalPortRange(local_port_range);
-        // expected response: body contains port number in specified range
-        // NOTE: even when trying up to 7000 ports there is the chance that all of them are occupied.
-        // It would be possible to also check here for ErrorCode::UNKNOWN_ERROR but that somehow seems
-        // wrong as then this test would pass in case SetLocalPort does not work at all
-        // or in other words: we have to assume that at least one port in the specified range is free.
-        response = session.Get();
-
-        if (response.error.code != ErrorCode::UNKNOWN_ERROR) {
-            break;
-        }
-    }
+    session.SetUrl(url);
+    uint16_t local_port{0};
+    ASSERT_NO_THROW(local_port = cpr::test::get_free_port());
+    uint16_t local_port_range{7000};
+    session.SetLocalPort(local_port);
+    session.SetLocalPortRange(local_port_range);
+    // expected response: body contains port number in specified range
+    // NOTE: even when trying up to 7000 ports there is the chance that all of them are occupied.
+    // It would be possible to also check here for ErrorCode::UNKNOWN_ERROR but that somehow seems
+    // wrong as then this test would pass in case SetLocalPort does not work at all
+    // or in other words: we have to assume that at least one port in the specified range is free.
+    response = session.Get();
 
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
@@ -1192,28 +1184,19 @@ TEST(LocalPortTests, SetLocalPortTest) {
 TEST(LocalPortTests, SetOptionTest) {
     Url url{server->GetBaseUrl() + "/local_port.html"};
     Session session;
-    uint16_t local_port{0};
-    uint16_t local_port_range{0};
     Response response;
-
-    // Try up to 10 times to get a free local port
-    for (size_t i = 0; i < 10; i++) {
-        session.SetUrl(url);
-        local_port = 30252 + (i * 100); // beware of HttpServer::GetPort when changing
-        local_port_range = 7000;
-        session.SetOption(LocalPort(local_port));
-        session.SetOption(LocalPortRange(local_port_range));
-        // expected response: body contains port number in specified range
-        // NOTE: even when trying up to 7000 ports there is the chance that all of them are occupied.
-        // It would be possible to also check here for ErrorCode::UNKNOWN_ERROR but that somehow seems
-        // wrong as then this test would pass in case SetLocalPort does not work at all
-        // or in other words: we have to assume that at least one port in the specified range is free.
-        response = session.Get();
-
-        if (response.error.code != ErrorCode::UNKNOWN_ERROR) {
-            break;
-        }
-    }
+    session.SetUrl(url);
+    uint16_t local_port{0};
+    uint16_t local_port_range{7000};
+    ASSERT_NO_THROW(local_port = cpr::test::get_free_port());
+    session.SetOption(LocalPort(local_port));
+    session.SetOption(LocalPortRange(local_port_range));
+    // expected response: body contains port number in specified range
+    // NOTE: even when trying up to 7000 ports there is the chance that all of them are occupied.
+    // It would be possible to also check here for ErrorCode::UNKNOWN_ERROR but that somehow seems
+    // wrong as then this test would pass in case SetLocalPort does not work at all
+    // or in other words: we have to assume that at least one port in the specified range is free.
+    response = session.Get();
 
     EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);

--- a/test/testUtils.cpp
+++ b/test/testUtils.cpp
@@ -1,0 +1,70 @@
+#include "testUtils.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+
+#ifdef _WIN32
+#define NOMINMAX
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+namespace cpr::test {
+
+std::uint16_t get_free_port() {
+#ifdef _WIN32
+    static const WSAInit wsa_guard; // one-time Winsock init
+#endif
+
+    // 1. Create a TCP socket.
+    socket_t sock = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (sock == INVALID_SOCKET_FD) {
+        throw std::runtime_error("socket() failed");
+    }
+
+    // 2. Bind to port 0 so the OS assigns an ephemeral port.
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons(0); // 0 ⇒ “pick for me”
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+#ifdef _WIN32
+        ::closesocket(sock);
+#else
+        ::close(sock);
+#endif
+        throw std::runtime_error("bind() failed");
+    }
+
+    // 3. Ask what port we actually got.
+    socklen_t len = sizeof(addr);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    if (::getsockname(sock, reinterpret_cast<sockaddr*>(&addr), &len) != 0) {
+#ifdef _WIN32
+        ::closesocket(sock);
+#else
+        ::close(sock);
+#endif
+        throw std::runtime_error("getsockname() failed");
+    }
+
+    std::uint16_t port = ntohs(addr.sin_port);
+
+    // 4. Close the socket ‒ we only needed it to grab the port number.
+#ifdef _WIN32
+    ::closesocket(sock);
+#else
+    ::close(sock);
+#endif
+
+    return port;
+}
+} // namespace cpr::test

--- a/test/testUtils.hpp
+++ b/test/testUtils.hpp
@@ -1,0 +1,37 @@
+#ifndef CPR_TEST_UTILS_H
+#define CPR_TEST_UTILS_H
+#include <cstdint>
+
+#ifdef _WIN32
+#define NOMINMAX
+#include <winsock2.h>
+#pragma comment(lib, "ws2_32.lib")
+#endif
+
+namespace cpr::test {
+
+#ifdef _WIN32
+using socket_t = SOCKET;
+constexpr socket_t INVALID_SOCKET_FD = INVALID_SOCKET;
+
+struct WSAInit {
+    WSAInit() {
+        WSADATA data;
+        if (WSAStartup(MAKEWORD(2, 2), &data) != 0) {
+            throw std::runtime_error("WSAStartup failed");
+        }
+    }
+    ~WSAInit() {
+        WSACleanup();
+    }
+};
+#else
+using socket_t = int;
+constexpr socket_t INVALID_SOCKET_FD = -1;
+#endif
+
+/// Return a currently unused TCP port.
+/// \throws std::runtime_error on failure.
+uint16_t get_free_port();
+} // namespace cpr::test
+#endif

--- a/test/testUtils_tests.cpp
+++ b/test/testUtils_tests.cpp
@@ -1,0 +1,16 @@
+#include <cstdint>
+#include <gtest/gtest.h>
+
+#include "testUtils.hpp"
+
+TEST(TestUtils, GetUnusedPort) {
+    uint16_t port{0};
+    ASSERT_NO_THROW(port = cpr::test::get_free_port());
+    EXPECT_NE(port, 0);
+}
+
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Changes
* Update to [CURL 8.13](https://github.com/curl/curl/releases/tag/curl-8_13_0)
* Fixed local port tests `errno` not being reset for CURL 8.13.
* Not guessing a free port but instead getting one from the system.