### PR TITLE
Ensure `cpr::LowSpeed` properties are cased to long for curl

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -489,8 +489,8 @@ void Session::SetBody(Body&& body) {
 }
 
 void Session::SetLowSpeed(const LowSpeed& low_speed) {
-    curl_easy_setopt(curl_->handle, CURLOPT_LOW_SPEED_LIMIT, low_speed.limit);
-    curl_easy_setopt(curl_->handle, CURLOPT_LOW_SPEED_TIME, low_speed.time); // cppcheck-suppress y2038-unsafe-call
+    curl_easy_setopt(curl_->handle, CURLOPT_LOW_SPEED_LIMIT, static_cast<long>(low_speed.limit));
+    curl_easy_setopt(curl_->handle, CURLOPT_LOW_SPEED_TIME, static_cast<long>(low_speed.time.count())); // cppcheck-suppress y2038-unsafe-call
 }
 
 void Session::SetVerifySsl(const VerifySsl& verify) {


### PR DESCRIPTION
Based on the docs, `std::chrono::seconds` is at least 36 bit long which would result in 64bit -> long and therefore it implicitly works on 64 bit systems.
https://en.cppreference.com/w/cpp/chrono/duration


BUT on 32 bit systems, we need `count()` and cast.