### PR TITLE
Add `primary_ip` `primary_port` to `Response`

### DIFF
--- a/cpr/response.cpp
+++ b/cpr/response.cpp
@@ -35,6 +35,18 @@ Response::Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text, std::
     uploaded_bytes = uploaded_bytes_double;
 #endif
     curl_easy_getinfo(curl_->handle, CURLINFO_REDIRECT_COUNT, &redirect_count);
+#if LIBCURL_VERSION_NUM >= 0x071300 // 7.19.0
+    char* ip_ptr{nullptr};
+    if (curl_easy_getinfo(curl_->handle, CURLINFO_PRIMARY_IP, &ip_ptr) == CURLE_OK && ip_ptr) {
+        primary_ip = ip_ptr;
+    }
+#endif
+#if LIBCURL_VERSION_NUM >= 0x071500 // 7.21.0
+    long port = 0;
+    if (curl_easy_getinfo(curl_->handle, CURLINFO_PRIMARY_PORT, &port) == CURLE_OK) {
+        primary_port = static_cast<uint16_t>(port);
+    }
+#endif
 }
 
 std::vector<CertInfo> Response::GetCertInfos() const {

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -42,6 +42,8 @@ class Response {
     // Ignored here since libcurl uses a long for this.
     // NOLINTNEXTLINE(google-runtime-int)
     long redirect_count{};
+    std::string primary_ip{};
+    uint16_t primary_port{};
 
     Response() = default;
     Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text, std::string&& p_header_string, Cookies&& p_cookies, Error&& p_error);

--- a/test/async_tests.cpp
+++ b/test/async_tests.cpp
@@ -27,6 +27,8 @@ TEST(AsyncTests, AsyncGetTest) {
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(response.primary_ip, "127.0.0.1");
+    EXPECT_EQ(response.primary_port, server->GetPort());
 }
 
 TEST(AsyncTests, AsyncGetMultipleTest) {


### PR DESCRIPTION
see https://github.com/libcpr/cpr/issues/1222 