### PR TITLE
Load all certs in a CaBuffer

### DIFF
--- a/cpr/ssl_ctx.cpp
+++ b/cpr/ssl_ctx.cpp
@@ -60,21 +60,6 @@ using custom_unique_ptr = std::unique_ptr<T, deleter_from_fn<fn>>;
 using x509_ptr = custom_unique_ptr<X509, X509_free>;
 using bio_ptr = custom_unique_ptr<BIO, BIO_free>;
 
-namespace {
-inline std::string get_openssl_print_errors() {
-    std::ostringstream oss;
-    ERR_print_errors_cb(
-            [](char const* str, size_t len, void* data) -> int {
-                auto& oss = *static_cast<std::ostringstream*>(data);
-                oss << str;
-                return static_cast<int>(len);
-            },
-            &oss);
-    return oss.str();
-}
-
-} // namespace
-
 CURLcode sslctx_function_load_ca_cert_from_buffer(CURL* /*curl*/, void* sslctx, void* raw_cert_buf) {
     // Check arguments
     if (raw_cert_buf == nullptr || sslctx == nullptr) {

--- a/cpr/ssl_ctx.cpp
+++ b/cpr/ssl_ctx.cpp
@@ -30,8 +30,9 @@
 #include <openssl/ossl_typ.h>
 #endif
 
-// openssl/pemerr.h was added in 1.1.1a
-#if OPENSSL_VERSION_NUMBER >= 0x1010101fL
+// openssl/pemerr.h was added in 1.1.1a, but not in BoringSSL
+// Ref https://github.com/libcpr/cpr/issues/333#issuecomment-2425104338
+#if OPENSSL_VERSION_NUMBER >= 0x1010101fL && !defined(OPENSSL_IS_BORINGSSL)
 #include <openssl/pemerr.h>
 #endif
 

--- a/cpr/ssl_ctx.cpp
+++ b/cpr/ssl_ctx.cpp
@@ -5,8 +5,6 @@
 #include <curl/curl.h>
 #include <iostream>
 #include <memory>
-#include <sstream>
-#include <string>
 
 #if SUPPORT_CURLOPT_SSL_CTX_FUNCTION
 
@@ -108,14 +106,14 @@ CURLcode sslctx_function_load_ca_cert_from_buffer(CURL* /*curl*/, void* sslctx, 
             ERR_print_errors_fp(stderr);
             BIO_free(bio);
             return CURLE_ABORTED_BY_CALLBACK;
-        } else {
-            certs_loaded++;
         }
+        certs_loaded++;
         // Free cert so we can load another one
         X509_free(cert);
         cert = nullptr;
     }
 
+    // NOLINTNEXTLINE(google-runtime-int) Ignored here since it is an API return value
     const unsigned long err = ERR_peek_last_error();
     if (certs_loaded == 0 && err != 0) {
         // Check if the error is just EOF or an actual parsing error

--- a/cpr/ssl_ctx.cpp
+++ b/cpr/ssl_ctx.cpp
@@ -69,8 +69,8 @@ CURLcode sslctx_function_load_ca_cert_from_buffer(CURL* /*curl*/, void* sslctx, 
 
     // Create a memory BIO using the data of cert_buf
     // Note: It is assumed, that cert_buf is nul terminated and its length is determined by strlen
-    auto cert_buf = static_cast<char*>(raw_cert_buf);
-    auto bio = BIO_new_mem_buf(cert_buf, -1);
+    char* cert_buf = static_cast<char*>(raw_cert_buf);
+    bio_ptr bio = BIO_new_mem_buf(cert_buf, -1);
 
     // Get a pointer to the current certificate verification storage
     X509_STORE* store = SSL_CTX_get_cert_store(static_cast<SSL_CTX*>(sslctx));
@@ -98,7 +98,7 @@ CURLcode sslctx_function_load_ca_cert_from_buffer(CURL* /*curl*/, void* sslctx, 
     //    ... base64 data ...
     //    -----END CERTIFICATE-----
     //
-    auto certs_loaded = 0;
+    size_t certs_loaded = 0;
     X509* cert = nullptr;
     while ((cert = PEM_read_bio_X509(bio, nullptr, nullptr, nullptr)) != nullptr) {
         const int status = X509_STORE_add_cert(store, cert);
@@ -116,7 +116,7 @@ CURLcode sslctx_function_load_ca_cert_from_buffer(CURL* /*curl*/, void* sslctx, 
         cert = nullptr;
     }
 
-    auto err = ERR_peek_last_error();
+    const unsigned long err = ERR_peek_last_error();
     if (certs_loaded == 0 && err != 0) {
         // Check if the error is just EOF or an actual parsing error
         if (ERR_GET_LIB(err) == ERR_LIB_PEM && ERR_GET_REASON(err) == PEM_R_NO_START_LINE) {

--- a/cpr/ssl_ctx.cpp
+++ b/cpr/ssl_ctx.cpp
@@ -70,7 +70,7 @@ CURLcode sslctx_function_load_ca_cert_from_buffer(CURL* /*curl*/, void* sslctx, 
     // Create a memory BIO using the data of cert_buf
     // Note: It is assumed, that cert_buf is nul terminated and its length is determined by strlen
     char* cert_buf = static_cast<char*>(raw_cert_buf);
-    bio_ptr bio = BIO_new_mem_buf(cert_buf, -1);
+    BIO* bio = BIO_new_mem_buf(cert_buf, -1);
 
     // Get a pointer to the current certificate verification storage
     X509_STORE* store = SSL_CTX_get_cert_store(static_cast<SSL_CTX*>(sslctx));


### PR DESCRIPTION
Hey! Thanks for the great project.

I noticed that `cpr::CaBuffer` doesn't load all certificates in the buffer: just the first one. `PEM_read_bio_X509` is meant to run in a loop (some [examples](https://github.com/search?q=PEM_read_bio_X509+%2B+while&type=code)) to add all certs in the buffer. This PR covers this.

It also fixes the inclusion of `openssl/pemerr.h` in BoringSSL, which doesn't exist. This closes https://github.com/libcpr/cpr/issues/333#issuecomment-2425104338

There's also an unused error printer that I removed, which caused issues with `-Werror`

Cheers!