### PR TITLE
Fix util namespaces to use the project with C++17 applications

### DIFF
--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -11,7 +11,8 @@
 #include "cpr/cprtypes.h"
 #include "cpr/secure_string.h"
 
-namespace cpr::util {
+namespace cpr{
+namespace util {
 
 Header parseHeader(const std::string& headers, std::string* status_line = nullptr, std::string* reason = nullptr);
 Cookies parseCookies(curl_slist* raw_cookies);
@@ -42,6 +43,7 @@ bool isTrue(const std::string& s);
  **/
 time_t sTimestampToT(const std::string&);
 
-} // namespace cpr::util
+} //namespace util
+} // namespace cpr
 
 #endif


### PR DESCRIPTION
It is ok to use library which is built with newer C++ standart but it will be great to have including headers to keep C++17 standart. 

Unfortunatly I need to use Qt5.15 which still use C++17. Moreover I cannot rebuild Qt5.15 with other C++ params I can use already built project ((. I think in some other cases such change can be required.