### PR TITLE
fix: callback function pointer type mismatch in writeFunction

### DIFF
--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -135,9 +135,9 @@ size_t headerUserFunction(char* ptr, size_t size, size_t nmemb, const HeaderCall
     return (*header)({ptr, size}) ? size : 0;
 }
 
-size_t writeFunction(char* ptr, size_t size, size_t nmemb, std::string* data) {
+size_t writeFunction(char* ptr, size_t size, size_t nmemb, void* data) {
     size *= nmemb;
-    data->append(ptr, size);
+    static_cast<std::string*>(data)->append(ptr, size);
     return size;
 }
 

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -17,7 +17,7 @@ Header parseHeader(const std::string& headers, std::string* status_line = nullpt
 Cookies parseCookies(curl_slist* raw_cookies);
 size_t readUserFunction(char* ptr, size_t size, size_t nitems, const ReadCallback* read);
 size_t headerUserFunction(char* ptr, size_t size, size_t nmemb, const HeaderCallback* header);
-size_t writeFunction(char* ptr, size_t size, size_t nmemb, std::string* data);
+size_t writeFunction(char* ptr, size_t size, size_t nmemb, void* data);
 size_t writeFileFunction(char* ptr, size_t size, size_t nmemb, std::ofstream* file);
 size_t writeUserFunction(char* ptr, size_t size, size_t nmemb, const WriteCallback* write);
 


### PR DESCRIPTION
The Undefined Behavior Sanitizer (UBSan) detected a mismatch in the function pointer type used for the writeFunction callback in CPR. Specifically, the error was:

```
runtime error: call to function cpr::util::writeFunction(char*, unsigned long, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>*) through pointer to incorrect function type 'unsigned long (*)(char *, unsigned long, unsigned long, void *)'
```