### PR TITLE
cpr::MultiPerform fixes - #1047 and #1186

### DIFF
--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -79,13 +79,6 @@ void MultiPerform::RemoveSession(const std::shared_ptr<Session>& session) {
         throw std::invalid_argument("Failed to find session!");
     }
 
-    // Remove easy handle from multihandle
-    const CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, session->curl_->handle);
-    if (error_code != CURLM_OK) {
-        std::cerr << "curl_multi_remove_handle() failed, code " << static_cast<int>(error_code) << '\n';
-        return;
-    }
-
     // Unlock session
     session->isUsedInMultiPerform = false;
 

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -49,7 +49,6 @@ MultiPerform::~MultiPerform() {
         const CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, session->curl_->handle);
         if (error_code) {
             std::cerr << "curl_multi_remove_handle() failed, code " << static_cast<int>(error_code) << '\n';
-            return;
         }
     }
 }
@@ -74,7 +73,6 @@ void MultiPerform::AddSession(std::shared_ptr<Session>& session, HttpMethod meth
 }
 
 void MultiPerform::RemoveSession(const std::shared_ptr<Session>& session) {
-    // Has to be handled before calling curl_multi_remove_handle to avoid it returning something != CURLM_OK.
     if (sessions_.empty()) {
         throw std::invalid_argument("Failed to find session!");
     }

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -27,6 +27,19 @@ MultiPerform::MultiPerform() : multicurl_(new CurlMultiHolder()) {
     first_interceptor_ = interceptors_.end();
 }
 
+MultiPerform::MultiPerform(MultiPerform&& old) noexcept {
+    *this = std::move(old);
+}
+
+MultiPerform& MultiPerform::operator=(MultiPerform&& old) noexcept {
+    sessions_ = std::move(old.sessions_);
+    multicurl_ = std::move(old.multicurl_);
+    interceptors_ = std::move(old.interceptors_);
+    current_interceptor_ = interceptors_.end();
+    first_interceptor_ = interceptors_.end();
+    return *this;
+}
+
 MultiPerform::~MultiPerform() {
     // Unlock all sessions
     for (const std::pair<std::shared_ptr<Session>, HttpMethod>& pair : sessions_) {

--- a/cpr/multiperform.cpp
+++ b/cpr/multiperform.cpp
@@ -162,6 +162,13 @@ std::vector<Response> MultiPerform::ReadMultiInfo(const std::function<Response(S
         }
     } while (info);
 
+    for (const auto& [session, _] : sessions_) {
+        const CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, session->curl_->handle);
+        if (error_code) {
+            std::cerr << "curl_multi_remove_handle() failed, code " << static_cast<int>(error_code) << '\n';
+        }
+    }
+
     // Sort response objects to match order of added sessions
     std::vector<Response> sorted_responses;
     for (const auto& [session, _] : sessions_) {
@@ -171,13 +178,6 @@ std::vector<Response> MultiPerform::ReadMultiInfo(const std::function<Response(S
         // Erase response from original vector to increase future search speed
         responses.erase(it);
         sorted_responses.push_back(current_response);
-    }
-
-    for (const auto& [session, _] : sessions_) {
-        const CURLMcode error_code = curl_multi_remove_handle(multicurl_->handle, session->curl_->handle);
-        if (error_code) {
-            std::cerr << "curl_multi_remove_handle() failed, code " << static_cast<int>(error_code) << '\n';
-        }
     }
     return sorted_responses;
 }

--- a/include/cpr/multiperform.h
+++ b/include/cpr/multiperform.h
@@ -30,11 +30,11 @@ class MultiPerform {
 
     MultiPerform();
     MultiPerform(const MultiPerform& other) = delete;
-    MultiPerform(MultiPerform&& old) = default;
+    MultiPerform(MultiPerform&& old) noexcept;
     ~MultiPerform();
 
     MultiPerform& operator=(const MultiPerform& other) = delete;
-    MultiPerform& operator=(MultiPerform&& old) noexcept = default;
+    MultiPerform& operator=(MultiPerform&& old) noexcept;
 
     std::vector<Response> Get();
     std::vector<Response> Delete();

--- a/test/multiperform_tests.cpp
+++ b/test/multiperform_tests.cpp
@@ -192,6 +192,68 @@ TEST(MultiperformGetTests, MultiperformRemoveSessionGetTest) {
     EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
 }
 
+TEST(MultiperformGetTests, MultiperformSingleSessionMultiGetTest) {
+    Url url{server->GetBaseUrl() + "/hello.html"};
+    std::shared_ptr<Session> session = std::make_shared<Session>();
+    session->SetUrl(url);
+    MultiPerform multiperform;
+    multiperform.AddSession(session);
+    std::vector<Response> responses = multiperform.Get();
+
+    EXPECT_EQ(responses.size(), 1);
+    std::string expected_text{"Hello world!"};
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+
+    // Invoke for the second time
+    responses = multiperform.Get(); // Fails here
+    EXPECT_EQ(responses.size(), 1);
+    EXPECT_EQ(expected_text, responses.at(0).text);
+    EXPECT_EQ(url, responses.at(0).url);
+    EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+    EXPECT_EQ(200, responses.at(0).status_code);
+    EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+}
+
+TEST(MultiperformGetTests, MultiperformAssignAfterUseTest) {
+    MultiPerform multiperform;
+    {
+        Url url{server->GetBaseUrl() + "/hello.html"};
+        std::shared_ptr<Session> session = std::make_shared<Session>();
+        session->SetUrl(url);
+        multiperform.AddSession(session);
+        std::vector<Response> responses = multiperform.Get();
+
+        EXPECT_EQ(responses.size(), 1);
+        std::string expected_text{"Hello world!"};
+        EXPECT_EQ(expected_text, responses.at(0).text);
+        EXPECT_EQ(url, responses.at(0).url);
+        EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+        EXPECT_EQ(200, responses.at(0).status_code);
+        EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+    }
+
+    {
+        Url url{server->GetBaseUrl() + "/hello.html"};
+        std::shared_ptr<Session> session = std::make_shared<Session>();
+        session->SetUrl(url);
+        multiperform = MultiPerform(); // This line does not work if the Muliperform object was used before
+        multiperform.AddSession(session);
+        std::vector<Response> responses = multiperform.Get();
+
+        EXPECT_EQ(responses.size(), 1);
+        std::string expected_text{"Hello world!"};
+        EXPECT_EQ(expected_text, responses.at(0).text);
+        EXPECT_EQ(url, responses.at(0).url);
+        EXPECT_EQ(std::string{"text/html"}, responses.at(0).header["content-type"]);
+        EXPECT_EQ(200, responses.at(0).status_code);
+        EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
+    }
+}
+
 #ifndef __APPLE__
 /**
  * This test case is currently disabled for macOS/Apple systems since it fails in an nondeterministic manner.

--- a/test/multiperform_tests.cpp
+++ b/test/multiperform_tests.cpp
@@ -208,8 +208,7 @@ TEST(MultiperformGetTests, MultiperformSingleSessionMultiGetTest) {
     EXPECT_EQ(200, responses.at(0).status_code);
     EXPECT_EQ(ErrorCode::OK, responses.at(0).error.code);
 
-    // Invoke for the second time
-    responses = multiperform.Get(); // Fails here
+    responses = multiperform.Get();
     EXPECT_EQ(responses.size(), 1);
     EXPECT_EQ(expected_text, responses.at(0).text);
     EXPECT_EQ(url, responses.at(0).url);
@@ -240,7 +239,7 @@ TEST(MultiperformGetTests, MultiperformAssignAfterUseTest) {
         Url url{server->GetBaseUrl() + "/hello.html"};
         std::shared_ptr<Session> session = std::make_shared<Session>();
         session->SetUrl(url);
-        multiperform = MultiPerform(); // This line does not work if the Muliperform object was used before
+        multiperform = MultiPerform();
         multiperform.AddSession(session);
         std::vector<Response> responses = multiperform.Get();
 


### PR DESCRIPTION
Fixes for #1047 and #1186. I took the liberty of changing cpr::Multiperform code to use structured bindings for better readability as well, but I can just revert that commit if so desired.

- #1047 was happening because easy handles added to a multi stack can't normally be reused, but we can work around that by removing and adding handles to the multi stack.

- #1186 was caused by the default move constructor and move assignment operator copying over the invalid `current_interceptor_` and `first_interceptor_` iterators from the moved-from MultiPerform object.