### PR TITLE
Refactor: Pass std::string_view by value instead of by const reference

### DIFF
--- a/include/cpr/callback.h
+++ b/include/cpr/callback.h
@@ -34,8 +34,8 @@ class HeaderCallback {
   public:
     HeaderCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    HeaderCallback(std::function<bool(const std::string_view& header, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
-    bool operator()(const std::string_view& header) const {
+    HeaderCallback(std::function<bool(std::string_view header, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    bool operator()(std::string_view header) const {
         if(!callback)
         {
             return true;
@@ -44,15 +44,15 @@ class HeaderCallback {
     }
 
     intptr_t userdata{};
-    std::function<bool(const std::string_view& header, intptr_t userdata)> callback;
+    std::function<bool(std::string_view header, intptr_t userdata)> callback;
 };
 
 class WriteCallback {
   public:
     WriteCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    WriteCallback(std::function<bool(const std::string_view& data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
-    bool operator()(const std::string_view& data) const {
+    WriteCallback(std::function<bool(std::string_view data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    bool operator()(std::string_view data) const {
         if(!callback)
         {
             return true;
@@ -61,7 +61,7 @@ class WriteCallback {
     }
 
     intptr_t userdata{};
-    std::function<bool(const std::string_view& data, intptr_t userdata)> callback;
+    std::function<bool(std::string_view data, intptr_t userdata)> callback;
 };
 
 class ProgressCallback {
@@ -94,17 +94,17 @@ class DebugCallback {
     };
     DebugCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    DebugCallback(std::function<void(InfoType type, std::string data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
-    void operator()(InfoType type, std::string data) const {
+    DebugCallback(std::function<void(InfoType type, std::string_view data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    void operator()(InfoType type, std::string_view data) const {
         if(!callback)
         {
             return;
         }
-        callback(type, std::move(data), userdata);
+        callback(type, data, userdata);
     }
 
     intptr_t userdata{};
-    std::function<void(InfoType type, std::string data, intptr_t userdata)> callback;
+    std::function<void(InfoType type, std::string_view data, intptr_t userdata)> callback;
 };
 
 /**

--- a/test/async_tests.cpp
+++ b/test/async_tests.cpp
@@ -14,7 +14,7 @@ using namespace cpr;
 
 static HttpServer* server = new HttpServer();
 
-bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
+bool write_data(std::string_view /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 

--- a/test/callback_tests.cpp
+++ b/test/callback_tests.cpp
@@ -857,7 +857,7 @@ TEST(CallbackDataTests, CallbackReadFunctionChunkedTest) {
 
 TEST(CallbackDataTests, CallbackHeaderFunctionCancelTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
-    Response response = Post(url, HeaderCallback{[](const std::string_view& /*header*/, intptr_t /*userdata*/) -> bool { return false; }});
+    Response response = Post(url, HeaderCallback{[](const std::string_view /*header*/, intptr_t /*userdata*/) -> bool { return false; }});
     EXPECT_TRUE((response.error.code == ErrorCode::ABORTED_BY_CALLBACK) || (response.error.code == ErrorCode::WRITE_ERROR));
 }
 
@@ -865,11 +865,11 @@ TEST(CallbackDataTests, CallbackHeaderFunctionTextTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
     std::vector<std::string> expected_headers{"HTTP/1.1 201 Created\r\n", "Content-Type: application/json\r\n", "\r\n"};
     std::set<std::string> response_headers;
-    Post(url, HeaderCallback{[&response_headers](const std::string_view& header, intptr_t /*userdata*/) -> bool {
+    Post(url, HeaderCallback{[&response_headers](const std::string_view header, intptr_t /*userdata*/) -> bool {
              response_headers.insert(std::string{header});
              return true;
          }});
-    for (std::string& header : expected_headers) {
+    for (const std::string& header : expected_headers) {
         std::cout << header << '\n';
         EXPECT_TRUE(response_headers.count(header));
     }
@@ -877,7 +877,7 @@ TEST(CallbackDataTests, CallbackHeaderFunctionTextTest) {
 
 TEST(CallbackDataTests, CallbackWriteFunctionCancelTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
-    Response response = Post(url, WriteCallback{[](const std::string_view& /*header*/, intptr_t /*userdata*/) -> bool { return false; }});
+    Response response = Post(url, WriteCallback{[](const std::string_view /*header*/, intptr_t /*userdata*/) -> bool { return false; }});
     EXPECT_TRUE((response.error.code == ErrorCode::ABORTED_BY_CALLBACK) || (response.error.code == ErrorCode::WRITE_ERROR));
 }
 
@@ -888,7 +888,7 @@ TEST(CallbackDataTests, CallbackWriteFunctionTextTest) {
             "  \"x\": 5\n"
             "}"};
     std::string response_text;
-    Post(url, Payload{{"x", "5"}}, WriteCallback{[&response_text](const std::string_view& header, intptr_t /*userdata*/) -> bool {
+    Post(url, Payload{{"x", "5"}}, WriteCallback{[&response_text](const std::string_view header, intptr_t /*userdata*/) -> bool {
              response_text.append(header);
              return true;
          }});
@@ -919,7 +919,7 @@ TEST(CallbackDataTests, CallbackDebugFunctionTextTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
     Body body{"x=5"};
     std::string debug_body;
-    Response response = Post(url, body, DebugCallback{[&](DebugCallback::InfoType type, const std::string& data, intptr_t /*userdata*/) {
+    Response response = Post(url, body, DebugCallback{[&](DebugCallback::InfoType type, std::string_view data, intptr_t /*userdata*/) {
                                  if (type == DebugCallback::InfoType::DATA_OUT) {
                                      debug_body = data;
                                  }

--- a/test/download_tests.cpp
+++ b/test/download_tests.cpp
@@ -15,7 +15,7 @@
 
 static cpr::HttpServer* server = new cpr::HttpServer();
 
-bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
+bool write_data(std::string_view /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 
@@ -123,7 +123,7 @@ TEST(DownloadTests, RangeTestMultipleRangesOption) {
     EXPECT_EQ(download_size, response.downloaded_bytes);
 }
 
-bool real_write_data(const std::string_view& data, intptr_t userdata) {
+bool real_write_data(std::string_view data, intptr_t userdata) {
     // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
     std::string* dst = reinterpret_cast<std::string*>(userdata);
     *dst += data;

--- a/test/interceptor_multi_tests.cpp
+++ b/test/interceptor_multi_tests.cpp
@@ -122,7 +122,7 @@ class ChangeRequestMethodToDeleteInterceptorMulti : public InterceptorMulti {
     }
 };
 
-bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
+bool write_data(std::string_view /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 

--- a/test/interceptor_tests.cpp
+++ b/test/interceptor_tests.cpp
@@ -94,7 +94,7 @@ class ChangeRequestMethodToDeleteInterceptor : public Interceptor {
     }
 };
 
-bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
+bool write_data(std::string_view /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 

--- a/test/multiperform_tests.cpp
+++ b/test/multiperform_tests.cpp
@@ -15,7 +15,7 @@ using namespace cpr;
 
 static HttpServer* server = new HttpServer();
 
-bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
+bool write_data(std::string_view /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 

--- a/test/session_tests.cpp
+++ b/test/session_tests.cpp
@@ -22,7 +22,7 @@ static HttpServer* server = new HttpServer();
 std::chrono::milliseconds sleep_time{50};
 std::chrono::seconds zero{0};
 
-bool write_data(const std::string_view& /*data*/, intptr_t /*userdata*/) {
+bool write_data(std::string_view /*data*/, intptr_t /*userdata*/) {
     return true;
 }
 


### PR DESCRIPTION
**Refactor: Pass std::string_view by value instead of by const reference**

Closes #1259.

As discussed in Issue #1259 , this PR refactors the codebase to pass `std::string_view` by value (e.g., `std::string_view`) instead of by `const std::string_view&`.

####  Changes Made

* Updated `HeaderCallback`'s `std::function` and `operator()` to use `std::string_view`.
* Updated `DebugCallback`'s `std::function` and `operator()` to use `std::string_view`.
* Updated `WriteCallback`'s `std::function` and `operator()` to use `std::string_view`.
* Updated relevant unit tests to use `std::string_view` in their lambda signatures. 
