### PR TITLE
Added support for CURLOPT_SSLCERT_BLOB

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -528,6 +528,20 @@ void Session::SetSslOptions(const SslOptions& options) {
             curl_easy_setopt(curl_->handle, CURLOPT_SSLCERTTYPE, options.cert_type.c_str());
         }
     }
+#if SUPPORT_CURLOPT_SSLCERT_BLOB
+    else if(!options.cert_blob.empty()) {
+        std::string cert_blob(options.cert_blob);
+        curl_blob blob{};
+        // NOLINTNEXTLINE (readability-container-data-pointer)
+        blob.data = &cert_blob[0];
+        blob.len = cert_blob.length();
+        blob.flags = CURL_BLOB_COPY;
+        curl_easy_setopt(curl_->handle, CURLOPT_SSLCERT_BLOB, &blob);
+        if (!options.cert_type.empty()) {
+            curl_easy_setopt(curl_->handle, CURLOPT_SSLCERTTYPE, options.cert_type.c_str());
+        }
+    }
+#endif
     if (!options.key_file.empty()) {
         curl_easy_setopt(curl_->handle, CURLOPT_SSLKEY, options.key_file.c_str());
         if (!options.key_type.empty()) {

--- a/test/ssl_tests.cpp
+++ b/test/ssl_tests.cpp
@@ -159,6 +159,27 @@ TEST(SslTests, LoadCertFromBufferTestSimpel) {
 }
 #endif
 
+#if SUPPORT_CURLOPT_SSLCERT_BLOB
+TEST(SslTests, LoadCertFromBlobTestSimpel) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    Url url{server->GetBaseUrl() + "/hello.html"};
+
+    std::string baseDirPath{server->getBaseDirPath()};
+    std::string crtPath{baseDirPath + "certificates/"};
+    std::string keyPath{baseDirPath + "keys/"};
+    std::string crtBuffer = loadFileContent(crtPath + "client.crt");
+    SslOptions sslOpts = Ssl(ssl::CaInfo{crtPath + "ca-bundle.crt"}, ssl::CertBlob{std::move(crtBuffer)}, ssl::KeyFile{keyPath + "client.key"}, ssl::VerifyPeer{true}, ssl::VerifyHost{true}, ssl::VerifyStatus{false});
+    Response response = cpr::Get(url, sslOpts, Timeout{5000}, Verbose{});
+    std::string expected_text = "Hello world!";
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code) << response.error.message;
+}
+#endif
+
 #if SUPPORT_CURLOPT_SSLKEY_BLOB
 TEST(SslTests, LoadKeyFromBlobTestSimpel) {
     std::this_thread::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
This PR adds support for setting the client certificate as a blob using CURLOPT_SSLCERT_BLOB instead of passing a file path.

Implemented like the existing CertFile option: CertBlob with an alias PemBlob and a derived DerBlob class. A matching test case is also there.