### PR TITLE
test: don't reflect Content-Length from request

### DIFF
--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -317,7 +317,7 @@ void HttpServer::OnRequestHeaderReflect(mg_connection* conn, mg_http_message* ms
             hasContentTypeHeader = true;
         }
 
-        if (std::string{"Host"} != name && std::string{"Accept"} != name) {
+        if (std::string{"Host"} != name && std::string{"Accept"} != name && std::string{"Content-Length"} != name) {
             if (header.value.ptr) {
                 headers.append(name + ": " + std::string(header.value.ptr, header.value.len) + "\r\n");
             }


### PR DESCRIPTION
Previously, POSTing to this endpoint would mean that the response would have two Content-Length headers: the one reflected from the request, and the new one that is for the response. This is improper, so this commit adds Content-Length to the headers excluded from reflection.

This was causing curl (as of 8.17.0, though the change might have happened earlier) to give a "weird server reply" error, which made several tests fail.