### PR TITLE
Updated Bazel Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,6 @@ ctest -VV # -VV is optional since it enables verbose output
 ```
 
 ### Bazel
-Please refer to [hedronvision/bazel-make-cc-https-easy](https://github.com/hedronvision/bazel-make-cc-https-easy) or
-
 `cpr` can be added as an extension by adding the following lines to your bazel MODULE file (tested with Bazel 8). Edit the versions as needed.
 ```starlark
 bazel_dep(name = "curl", version = "8.8.0.bcr.3")

--- a/README.md
+++ b/README.md
@@ -168,7 +168,13 @@ load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 filegroup(
     name = "srcs",
-    srcs = glob(["**"], ["bazel-*/**"]),
+    srcs = glob(
+        include = ["**"],
+        exclude = [
+            "bazel-*/**",
+            "test/data/**",  # Exclude test data.
+        ],
+    ),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
**CMake Approach Issues**

_First Issue_
Non-ASCII characters cannot be parsed by glob. 

```
ERROR: /root/.cache/bazel/_bazel_root/646bcbb063181c5dac5a581e1c4fefdd/external/_main~_repo_rules~cpr/BUILD.bazel:22:6: Foreign Cc - CMake: Building cpr failed: error reading file '@@_main~_repo_rules~cpr//:test/data/test_file_hello_äüöp_2585_你好.txt': /root/.cache/bazel/_bazel_root/646bcbb063181c5dac5a581e1c4fefdd/external/_main~_repo_rules~cpr/test/data/test_file_hello_äüöp_2585_你好.txt (No such file or directory)
```

_Second Issue_
Resolving this error still causes an issue with `<filesystem>`. I was unable to override C++17 for C++20 to make this work with the `cmake` toolchain.

**Repo Reference Issue**
In addition, the referenced Bazel repo is deprecated by several years. I was unable to get them to work with BAZEL modules.

**Solution**
Use Bazel to build the project with a patch to remove the generated version file `cpr/cprver.h` (only created with the CMake command). 

This was confirmed to work on Ubuntu 24.04. Modifications should be straightforward for Bazel users on Windows or Mac as it uses common toolchains.