### PR TITLE
⚡️ Share SSL session data in ConnectionPool for TLS session resumption

### DIFF
--- a/cpr/connection_pool.cpp
+++ b/cpr/connection_pool.cpp
@@ -19,6 +19,7 @@ ConnectionPool::ConnectionPool() {
     };
 
     curl_share_setopt(curl_share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+    curl_share_setopt(curl_share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
     curl_share_setopt(curl_share, CURLSHOPT_USERDATA, this->connection_mutex_.get());
     curl_share_setopt(curl_share, CURLSHOPT_LOCKFUNC, lock_f);
     curl_share_setopt(curl_share, CURLSHOPT_UNLOCKFUNC, unlock_f);


### PR DESCRIPTION
Without this, each new easy handle using the shared connection pool must perform a full TLS handshake even when reusing a pooled TCP connection. Sharing `CURL_LOCK_DATA_SSL_SESSION` allows libcurl to resume TLS sessions across handles.