### PR TITLE
Make warnings-as-errors configurable and fix pedantic semicolon warning

### DIFF
--- a/cpr/async.cpp
+++ b/cpr/async.cpp
@@ -3,6 +3,6 @@
 namespace cpr {
 
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
-CPR_SINGLETON_IMPL(GlobalThreadPool);
+CPR_SINGLETON_IMPL(GlobalThreadPool)
 
 } // namespace cpr


### PR DESCRIPTION
## Summary

This PR makes `-Werror` configurable through a new CMake option:

```cmake
CPR_WARNINGS_AS_ERRORS
```

Default behavior remains unchanged (`ON`).

## Motivation

Some downstream projects and newer compiler versions may emit pedantic warnings that should not always fail the build. This change allows users to disable `-Werror` while still keeping warning flags enabled.

## Changes

* Added `CPR_WARNINGS_AS_ERRORS` option
* Separated warning flags from `-Werror`
* Preserved existing default behavior
* Fixed pedantic semicolon warning in `async.cpp`
