### PR TITLE
Add operator to fetch cookies by their key

### DIFF
--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -1,5 +1,7 @@
 #include "cpr/cookies.h"
 #include "cpr/curlholder.h"
+
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 #include <iomanip>
@@ -73,14 +75,14 @@ cpr::Cookie& Cookies::operator[](size_t pos) {
     return cookies_[pos];
 }
 
-cpr::Cookie& Cookies::operator[](std::string key) {
-    // Using a C-style for loop to get the index of the cookie within the vector, this allows returning references
-    for (size_t i = 0; i < cookies_.size(); i++) { // NOLINT(*-loop-convert)
-        if (cookies_[i].GetName() == key) {
-            return cookies_[i];
-        }
+cpr::Cookie& Cookies::operator[](const std::string& key) {
+    const auto it = std::find_if(cookies_.begin(), cookies_.end(), [key](const cpr::Cookie& c) { return c.GetName() == key; });
+
+    if (it == cookies_.end()) {
+        throw std::out_of_range{"Cookie: " + key + " does not exist"};
     }
-    throw std::out_of_range {"Cookie: " + key + " does not exist"};
+
+    return *it;
 }
 
 Cookies::iterator Cookies::begin() {

--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -73,6 +73,16 @@ cpr::Cookie& Cookies::operator[](size_t pos) {
     return cookies_[pos];
 }
 
+cpr::Cookie& Cookies::operator[](std::string key) {
+    // Using a C-style for loop to get the index of the cookie within the vector, this allows returning references
+    for (size_t i = 0; i < cookies_.size(); i++) { // NOLINT(*-loop-convert)
+        if (cookies_[i].GetName() == key) {
+            return cookies_[i];
+        }
+    }
+    throw std::out_of_range {"Cookie: " + key + " does not exist"};
+}
+
 Cookies::iterator Cookies::begin() {
     return cookies_.begin();
 }

--- a/include/cpr/cookies.h
+++ b/include/cpr/cookies.h
@@ -65,6 +65,7 @@ class Cookies {
     Cookies(const cpr::Cookie& cookie, bool p_encode = true) : encode{p_encode}, cookies_{cookie} {}
 
     cpr::Cookie& operator[](size_t pos);
+    cpr::Cookie& operator[](std::string key);
     [[nodiscard]] std::string GetEncoded(const CurlHolder& holder) const;
 
     using iterator = std::vector<cpr::Cookie>::iterator;

--- a/include/cpr/cookies.h
+++ b/include/cpr/cookies.h
@@ -65,7 +65,7 @@ class Cookies {
     Cookies(const cpr::Cookie& cookie, bool p_encode = true) : encode{p_encode}, cookies_{cookie} {}
 
     cpr::Cookie& operator[](size_t pos);
-    cpr::Cookie& operator[](std::string key);
+    cpr::Cookie& operator[](const std::string& key);
     [[nodiscard]] std::string GetEncoded(const CurlHolder& holder) const;
 
     using iterator = std::vector<cpr::Cookie>::iterator;


### PR DESCRIPTION
The main idea of this PR is to add the ability to fetch cookies by their individual key from a cpr::Cookies object. calling the `[]` operator on a string storing the cookie name would return the actual cookie with that name, if not, it throws `std::out_of_range`. Looping through the list of cookies produces annoying boilerplate code, and this would fix that. I'm a new C++ programmer; worse yet, my introduction to C++ was with version 98, so I won't be offended by quite possibly a lot of feedback.

I already have these concerns with my own PR, however.

1. The idea of a Cookies object is to be vector-like, and this code intentionally more map-like; I'm not sure if the very concept is out-of-place or not.
2. Looping through cookies like this could become very inefficient for large cookie lists (I'm not sure if that kind of speed is a priority in cpr or not).
3. There's always the problem of a given cookie not being possible to find, I'd love some help on whether throwing `std::out_of_range` is the right way to handle that.