### PR TITLE
restore native ca ssl option by default

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -154,6 +154,11 @@ Session::Session() : curl_(new CurlHolder()) {
     curl_easy_setopt(curl_->handle, CURLOPT_NOSIGNAL, 1L);
 #endif
 
+#if LIBCURL_VERSION_NUM >= 0x074700 // 7.71.0
+    // Fix loading certs from Windows cert store when using OpenSSL:
+    curl_easy_setopt(curl_->handle, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+#endif
+
 #if LIBCURL_VERSION_NUM >= 0x071900 // 7.25.0
     curl_easy_setopt(curl_->handle, CURLOPT_TCP_KEEPALIVE, 1L);
 #endif


### PR DESCRIPTION
## what changed

restore CURLSSLOPT_NATIVE_CA when a Session is constructed on curl 7.71.0 and newer.

## why

#1128 correctly changed CURLOPT_SSL_OPTIONS to use one combined bitmask, but it moved the native-ca setting into SetSslOptions. that method is only called when ssl options are explicitly configured, so normal sessions no longer enable the native ca behavior on windows with openssl.

this keeps the bitmask fix in place while restoring the default constructor behavior. it also leaves the request preparation path free of repeated ssl-option writes.

## checks

- git diff --check passes.
- the local checkout does not have cmake or a c++ compiler installed, so i could not run the project test suite locally.

fixes #1313