### PR TITLE
Fix malformed sha tag

### DIFF
--- a/.github/workflows/readme-updater.yml
+++ b/.github/workflows/readme-updater.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         ref: ${{github.sha}}
     - name: "Replace GIT_TAG"
-      run: sed -i -re 's/(GIT_TAG) [0-9a-f]+/\1 ${{github.sha}}/' README.md
+      run: sed -i -re 's/(GIT_TAG) [^ )]+/\1 ${{github.sha}}/' README.md
     - name: "Commit changes"
       uses: stefanzweifel/git-auto-commit-action@v7
       with:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add the following to your `CMakeLists.txt`.
 ```cmake
 include(FetchContent)
 FetchContent_Declare(cpr GIT_REPOSITORY https://github.com/libcpr/cpr.git
-                         GIT_TAG f091b2c061b307ee89b164c39976fc9202a1c79d.12.0) # Replace with your desired git commit from: https://github.com/libcpr/cpr/releases
+                         GIT_TAG f091b2c061b307ee89b164c39976fc9202a1c79d) # Replace with your desired git commit from: https://github.com/libcpr/cpr/releases
 FetchContent_MakeAvailable(cpr)
 ```
 


### PR DESCRIPTION
Fixes #1317 

## Changes:
- README.md: drops the `.12.0` so the snippet pins the bare commit SHA.
- readme-updater.yml: change the pattern to `(GIT_TAG) [^ )]+` so it
  replaces the whole token whatever its shape (SHA or dotted version) and
  stops at the closing paren. This should prevent partial-match leftovers

Verified the new expression against both historical shapes — `GIT_TAG 1.12.0)`
and `GIT_TAG f091…79d.12.0)` each come out as `GIT_TAG <new-sha>)`.